### PR TITLE
Fixed GetAlbumArtURL Issue

### DIFF
--- a/SpotifyAPI/SpoitfyLocalAPI/Track.cs
+++ b/SpotifyAPI/SpoitfyLocalAPI/Track.cs
@@ -104,7 +104,7 @@ namespace SpotifyAPI.SpotifyLocalAPI
             string[] lines = raw.Split(new string[] { "\n" }, StringSplitOptions.None);
             foreach (string line in lines)
             {
-                if (line.StartsWith("<meta property=\"og:image\""))
+                if (line.Trim().StartsWith("<meta property=\"og:image\""))
                 {
                     string[] l = line.Split(new string[] { "/" }, StringSplitOptions.None);
                     return "http://o.scdn.co/" + albumsize + @"/" + l[4].Replace("\"", "").Replace(">", "");


### PR DESCRIPTION
Album art wasn't downloading properly because of whitespace at the beginning of line. Will now remove whitespace before comparing.
