### PR TITLE
Added support for the beta version of Spotify Desktop to the SpotifyLocalAPIClass

### DIFF
--- a/SpotifyAPI/SpoitfyLocalAPI/SpotifyAPI.cs
+++ b/SpotifyAPI/SpoitfyLocalAPI/SpotifyAPI.cs
@@ -11,11 +11,18 @@ namespace SpotifyAPI.SpotifyLocalAPI
         SpotifyMusicHandler mh;
         RemoteHandler rh;
         SpotifyEventHandler eh;
+        static bool betaMode = false;
+
         public SpotifyLocalAPIClass()
         {
             rh = RemoteHandler.GetInstance();
             mh = new SpotifyMusicHandler();
             eh = new SpotifyEventHandler(this, mh);
+        }
+
+        public SpotifyLocalAPIClass(bool betaMode) : this()
+        {
+            SpotifyLocalAPIClass.betaMode = betaMode;
         }
 
         /// <summary>
@@ -26,6 +33,7 @@ namespace SpotifyAPI.SpotifyLocalAPI
         {
             return rh.Init();
         }
+
         /// <summary>
         /// Returns the MusicHandler
         /// </summary>
@@ -34,6 +42,7 @@ namespace SpotifyAPI.SpotifyLocalAPI
         {
             return mh;
         }
+
         /// <summary>
         /// Returns the EventHanlder
         /// </summary>
@@ -42,42 +51,57 @@ namespace SpotifyAPI.SpotifyLocalAPI
         {
             return eh;
         }
+
         /// <summary>
         /// Checks if Spotify is running
         /// </summary>
         /// <returns>True, if it's running, false if not</returns>
         public static Boolean IsSpotifyRunning()
         {
-            if (Process.GetProcessesByName("spotify").Length < 1)
+            var procName = (betaMode) ? "spotifybeta" : "spotify";
+
+            if (Process.GetProcessesByName(procName).Length < 1)
                 return false;
+
             return true;
         }
+
         /// <summary>
         /// Checks if Spotify's WebHelper is running (Needed for API Calls)
         /// </summary>
         /// <returns>True, if it's running, false if not</returns>
         public static Boolean IsSpotifyWebHelperRunning()
         {
-            if (Process.GetProcessesByName("SpotifyWebHelper").Length < 1)
+            var procName = (betaMode) ? "spotifybetawebhelper" : "spotifywebhelper";
+
+            if (Process.GetProcessesByName(procName).Length < 1)
                 return false;
+
             return true;
         }
+
         /// <summary>
         /// Runs Spotify
         /// </summary>
         public void RunSpotify()
         {
-            if(!IsSpotifyRunning())
-                Process.Start(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Spotify\\spotify.exe");
+            var pathToExe = (betaMode) ? @"\spotifybeta\spotifybeta.exe" : @"\spotify\spotify.exe";
+
+            if (!IsSpotifyRunning())
+                Process.Start(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + pathToExe);
         }
+
         /// <summary>
         /// Runs Spotify's WebHelper
         /// </summary>
         public void RunSpotifyWebHelper()
         {
+            var pathToExe = (betaMode) ? @"\spotifybeta\spotifybetawebhelper.exe" : @"\spotify\data\spotifywebhelper.exe";
+
             if (!IsSpotifyWebHelperRunning())
-                Process.Start(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Spotify\\Data\\SpotifyWebHelper.exe");
+                Process.Start(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + pathToExe);
         }
+
         /// <summary>
         /// Checks for a valid SpotifyURL (Still not finished)
         /// </summary>
@@ -85,12 +109,15 @@ namespace SpotifyAPI.SpotifyLocalAPI
         /// <returns>True if the URI is valid, false if not</returns>
         public static Boolean IsValidSpotifyURI(String uri)
         {
-            String[] types = new String[] { "track","album","local","artist"};
+            String[] types = new String[] { "track", "album", "local", "artist" };
             String[] split = uri.Split(':');
+            
             if (split.Length < 3)
                 return false;
+            
             return split[0] == "spotify" && Array.IndexOf(types, split[1]) > -1 && split[2].Length == 22;
         }
+
         /// <summary>
         /// Updates and Fetches all current information about the current track etc.
         /// </summary>
@@ -98,6 +125,7 @@ namespace SpotifyAPI.SpotifyLocalAPI
         {
             if (!SpotifyLocalAPIClass.IsSpotifyWebHelperRunning() || !SpotifyLocalAPIClass.IsSpotifyRunning())
                 return;
+
             mh.Update(rh.Update());
         }
     }

--- a/SpotifyAPI/SpoitfyLocalAPI/SpotifyAPI.cs
+++ b/SpotifyAPI/SpoitfyLocalAPI/SpotifyAPI.cs
@@ -11,17 +11,13 @@ namespace SpotifyAPI.SpotifyLocalAPI
         SpotifyMusicHandler mh;
         RemoteHandler rh;
         SpotifyEventHandler eh;
-        static bool betaMode = false;
+        static bool betaMode;
 
-        public SpotifyLocalAPIClass()
+        public SpotifyLocalAPIClass(bool betaMode = false)
         {
             rh = RemoteHandler.GetInstance();
             mh = new SpotifyMusicHandler();
             eh = new SpotifyEventHandler(this, mh);
-        }
-
-        public SpotifyLocalAPIClass(bool betaMode) : this()
-        {
             SpotifyLocalAPIClass.betaMode = betaMode;
         }
 

--- a/SpotifyLocalAPIExample/Form1.cs
+++ b/SpotifyLocalAPIExample/Form1.cs
@@ -23,7 +23,7 @@ namespace SpotifyAPI_Example
         public Form1()
         {
             InitializeComponent();
-            spotify = new SpotifyLocalAPIClass();
+            spotify = new SpotifyLocalAPIClass(true);
             if (!SpotifyLocalAPIClass.IsSpotifyRunning())
             {
                 spotify.RunSpotify();

--- a/SpotifyLocalAPIExample/Form1.cs
+++ b/SpotifyLocalAPIExample/Form1.cs
@@ -23,7 +23,7 @@ namespace SpotifyAPI_Example
         public Form1()
         {
             InitializeComponent();
-            spotify = new SpotifyLocalAPIClass(true);
+            spotify = new SpotifyLocalAPIClass();
             if (!SpotifyLocalAPIClass.IsSpotifyRunning())
             {
                 spotify.RunSpotify();


### PR DESCRIPTION
Basically, enables a developer to target the official release or the beta release via an optional parameter in SpotifyLocalAPIClass's constructor. Based on that setting, the library will target the spotify.exe/spotifywebhelper.exe official executables or the spotifybeta.exe/spotifybetawebhelper.exe beta executables. You can install the beta from [here](https://community.spotify.com/t5/Help-Desktop-Linux-Mac-and/Welcome-to-the-Desktop-Beta/m-p/932803/highlight/true#M98371). Note that it installs side by side with the official release. 