### PR TITLE
Fixed null Uri issue when playing ads

### DIFF
--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -28,8 +28,9 @@ namespace SpotifyAPI.Local.Models
         /// <returns>A String, which is the URL to the Albumart</returns>
         public String GetAlbumArtUrl(AlbumArtSize size)
         {
-            if (AlbumResource.Uri.Contains("local"))
+            if (AlbumResource.Uri == null || AlbumResource.Uri.Contains("local"))
                 return "";
+
             int albumsize = 0;
             switch (size)
             {


### PR DESCRIPTION
Checks for null Uri before attempting to read it