### PR TITLE
Fixed process start for application and webhelper

### DIFF
--- a/SpotifyAPI/Local/SpotifyLocalAPI.cs
+++ b/SpotifyAPI/Local/SpotifyLocalAPI.cs
@@ -247,8 +247,8 @@ namespace SpotifyAPI.Local
         /// </summary>
         public static void RunSpotify()
         {
-            if (!IsSpotifyRunning())
-                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\spotify.exe"));
+            if (!IsSpotifyRunning()) 
+                Process.Start(string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\spotify.exe"));
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace SpotifyAPI.Local
         public static void RunSpotifyWebHelper()
         {
             if (!IsSpotifyWebHelperRunning())
-                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\data\spotifywebhelper.exe"));
+                Process.Start(string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\data\spotifywebhelper.exe"));
         }
     }
 }

--- a/SpotifyAPI/Local/SpotifyLocalAPI.cs
+++ b/SpotifyAPI/Local/SpotifyLocalAPI.cs
@@ -248,7 +248,7 @@ namespace SpotifyAPI.Local
         public static void RunSpotify()
         {
             if (!IsSpotifyRunning()) 
-                Process.Start(string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\spotify.exe"));
+                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\spotify.exe"));
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace SpotifyAPI.Local
         public static void RunSpotifyWebHelper()
         {
             if (!IsSpotifyWebHelperRunning())
-                Process.Start(string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\spotify\data\spotifywebhelper.exe"));
+                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\data\spotifywebhelper.exe"));
         }
     }
 }


### PR DESCRIPTION
The method Path.Combine() does not work (it has no string-based return of the combined value with AppData-path and the const string values for spotify.exe and spotifywebhelper.exe). 