### PR TITLE
Check Tracktype on "local" instead of AlbumResource.Uri

### DIFF
--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -28,7 +28,7 @@ namespace SpotifyAPI.Local.Models
         /// <returns>A String, which is the URL to the Albumart</returns>
         public String GetAlbumArtUrl(AlbumArtSize size)
         {
-            if (AlbumResource.Uri == null || AlbumResource.Uri.Contains("local"))
+            if (AlbumResource.Uri == null || TrackType.Contains("local"))
                 return "";
 
             int albumsize = 0;


### PR DESCRIPTION
This property will contain the correct value to compare it with. Application will crash otherwise if file is played local.