### PR TITLE
Added AlbumResource Check

### DIFF
--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -28,7 +28,7 @@ namespace SpotifyAPI.Local.Models
         /// <returns>A String, which is the URL to the Albumart</returns>
         public String GetAlbumArtUrl(AlbumArtSize size)
         {
-            if (AlbumResource.Uri == null || AlbumResource.Uri.Contains("local"))
+            if (AlbumResource.Uri == null || AlbumResource.Uri.Contains("local") || AlbumResource.Uri.Contains("spotify:album:0000000000000000000000"))
                 return "";
 
             int albumsize = 0;


### PR DESCRIPTION
A local file (not localized by spotify i suppose) will return "spotify:album:0000000000000000000000" - the application will crash trying to get the album url otherwise.