### PR TITLE
Remove setting the WebClient.Proxy to null

### DIFF
--- a/SpotifyAPI/Local/ExtendedWebClient.cs
+++ b/SpotifyAPI/Local/ExtendedWebClient.cs
@@ -10,7 +10,6 @@ namespace SpotifyAPI.Local
         public ExtendedWebClient()
         {
             Timeout = 2000;
-            Proxy = null;
             Headers.Add("Origin", "https://embed.spotify.com");
             Headers.Add("Referer", "https://embed.spotify.com/?uri=spotify:track:5Zp4SWOpbuOdnsxLqwgutt");
         }

--- a/SpotifyAPI/Local/RemoteHandler.cs
+++ b/SpotifyAPI/Local/RemoteHandler.cs
@@ -62,7 +62,6 @@ namespace SpotifyAPI.Local
             String raw;
             using (WebClient wc = new WebClient())
             {
-                wc.Proxy = null;
                 raw = wc.DownloadString("http://open.spotify.com/token");
             }
             Dictionary<String, object> dic = JsonConvert.DeserializeObject<Dictionary<String, object>>(raw);


### PR DESCRIPTION
It should be fine in most of the cases to just use the system proxy settings.
If anyone has issues with this approach, we can still make the WebClient.Proxy setting configurable somehow.

This is the pull request for the issue #57.