### PR TITLE
Change type to album_type as per API docs

### DIFF
--- a/SpotifyAPI/Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI/Web/SpotifyWebBuilder.cs
@@ -144,7 +144,7 @@ namespace SpotifyAPI.Web
         {
             limit = Math.Min(limit, 50);
             StringBuilder builder = new StringBuilder(APIBase + "/artists/" + id + "/albums");
-            builder.Append("?type=" + type.GetStringAttribute(","));
+            builder.Append("?album_type=" + type.GetStringAttribute(","));
             builder.Append("&limit=" + limit);
             builder.Append("&offset=" + offset);
             if (!String.IsNullOrEmpty(market))


### PR DESCRIPTION
When filtering by album type, the parameter is not type, but album_type

See https://developer.spotify.com/web-api/get-artists-albums/