### PR TITLE
Use separator when joining string attributes

### DIFF
--- a/SpotifyAPI/Web/Util.cs
+++ b/SpotifyAPI/Web/Util.cs
@@ -20,7 +20,7 @@ namespace SpotifyAPI.Web
 
             List<String> list = new List<String>();
             attributes.ToList().ForEach(element => list.Add(element.Text));
-            return string.Join(" ", list);
+            return string.Join(separator, list);
         }
     }
 


### PR DESCRIPTION
"separator" wasn't being used, resulting in a bug when filtering album searches by more than one type.