### PR TITLE
Properly dispose http server

### DIFF
--- a/SpotifyAPI/Web/Auth/AutorizationCodeAuth.cs
+++ b/SpotifyAPI/Web/Auth/AutorizationCodeAuth.cs
@@ -111,6 +111,7 @@ namespace SpotifyAPI.Web.Auth
         /// </summary>
         public void StopHttpServer()
         {
+            _httpServer.Dispose();
             _httpServer = null;
         }
 


### PR DESCRIPTION
When using the AuthorizationCodeAuth flow, the HTTP server should be stopped properly like in ImplicitGrantAuth