### PR TITLE
Corrected url in CheckSavedAlbum method.

### DIFF
--- a/SpotifyAPI/Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI/Web/SpotifyWebBuilder.cs
@@ -540,7 +540,7 @@ namespace SpotifyAPI.Web
         /// <remarks>AUTH NEEDED</remarks>
         public string CheckSavedAlbums(List<string> ids)
         {
-            return APIBase + "/me/tracks/contains?ids=" + string.Join(",", ids);
+            return APIBase + "/me/albums/contains?ids=" + string.Join(",", ids);
         }
 
         #endregion Library


### PR DESCRIPTION
The CheckSavedAlbum client implementation used the incorrect url, which made it check for a saved tracked. This resulted in a always false response from the Spotify servers.