### PR TITLE
Configure await fix + removed bunch of unnecessary async/await before return

### DIFF
--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -103,7 +103,9 @@ namespace SpotifyAPI.Local.Models
                 string url = GetAlbumArtUrl(size);
                 if (url == "")
                     return null;
-                var data = await wc.DownloadDataTaskAsync(url);
+                var data = 
+                    
+                    wc.DownloadDataTaskAsync(url);
                 using (MemoryStream ms = new MemoryStream(data))
                 {
                     return (Bitmap)Image.FromStream(ms);
@@ -116,7 +118,7 @@ namespace SpotifyAPI.Local.Models
         /// </summary>
         /// <param name="size">AlbumArtSize (160,320,640)</param>
         /// <returns>A byte[], which is the albumart in binary data</returns>
-        public async Task<byte[]> GetAlbumArtAsByteArrayAsync(AlbumArtSize size)
+        public Task<byte[]> GetAlbumArtAsByteArrayAsync(AlbumArtSize size)
         {
             using (WebClient wc = new WebClient())
             {
@@ -124,7 +126,7 @@ namespace SpotifyAPI.Local.Models
                 string url = GetAlbumArtUrl(size);
                 if (url == "")
                     return null;
-                return await wc.DownloadDataTaskAsync(url);
+                return wc.DownloadDataTaskAsync(url);
             }
         }
 

--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -103,9 +103,7 @@ namespace SpotifyAPI.Local.Models
                 string url = GetAlbumArtUrl(size);
                 if (url == "")
                     return null;
-                var data = 
-                    
-                    wc.DownloadDataTaskAsync(url);
+                var data = await wc.DownloadDataTaskAsync(url).ConfigureAwait(false);
                 using (MemoryStream ms = new MemoryStream(data))
                 {
                     return (Bitmap)Image.FromStream(ms);

--- a/SpotifyAPI/Local/RemoteHandler.cs
+++ b/SpotifyAPI/Local/RemoteHandler.cs
@@ -24,23 +24,23 @@ namespace SpotifyAPI.Local
 
         internal async void SendPauseRequest()
         {
-            await QueryAsync("remote/pause.json?pause=true", true, true, -1);
+            await QueryAsync("remote/pause.json?pause=true", true, true, -1).ConfigureAwait(false);
         }
 
         internal async void SendPlayRequest()
         {
-            await QueryAsync("remote/pause.json?pause=false", true, true, -1);
+            await QueryAsync("remote/pause.json?pause=false", true, true, -1).ConfigureAwait(false);
         }
 
         internal async void SendPlayRequest(string url, string context = "")
         {
             // TODO: instead of having an empty context, one way to fix the bug with the playback time beyond the length of a song would be to provide a 1-song context, and it would be fixed.
-            await QueryAsync($"remote/play.json?uri={url}&context={context}", true, true, -1);
+            await QueryAsync($"remote/play.json?uri={url}&context={context}", true, true, -1).ConfigureAwait(false);
         }
 
         internal async void SendQueueRequest(string url)
         {
-            await QueryAsync("remote/play.json?uri=" + url + "?action=queue", true, true, -1);
+            await QueryAsync("remote/play.json?uri=" + url + "?action=queue", true, true, -1).ConfigureAwait(false);
         }
 
         internal StatusResponse GetNewStatus()
@@ -151,7 +151,7 @@ namespace SpotifyAPI.Local
                 using (var wc = new ExtendedWebClient())
                 {
                     if (SpotifyLocalAPI.IsSpotifyRunning())
-                        response = "[ " + await wc.DownloadStringTaskAsync(new Uri(address)) + " ]";
+                        response = "[ " + await wc.DownloadStringTaskAsync(new Uri(address)).ConfigureAwait(false) + " ]";
                 }
             }
             catch

--- a/SpotifyAPI/Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI/Web/SpotifyWebAPI.cs
@@ -110,9 +110,9 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first result to return. Default: 0</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code or the string from_token.</param>
         /// <returns></returns>
-        public async Task<SearchItem> SearchItemsAsync(string q, SearchType type, int limit = 20, int offset = 0, string market = "")
+        public Task<SearchItem> SearchItemsAsync(string q, SearchType type, int limit = 20, int offset = 0, string market = "")
         {
-            return await DownloadDataAsync<SearchItem>(_builder.SearchItems(q, type, limit, offset, market));
+            return DownloadDataAsync<SearchItem>(_builder.SearchItems(q, type, limit, offset, market));
         }
 
         #endregion Search
@@ -142,9 +142,9 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first track to return. Default: 0 (the first object).</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
-        public async Task<Paging<SimpleTrack>> GetAlbumTracksAsync(string id, int limit = 20, int offset = 0, string market = "")
+        public Task<Paging<SimpleTrack>> GetAlbumTracksAsync(string id, int limit = 20, int offset = 0, string market = "")
         {
-            return await DownloadDataAsync<Paging<SimpleTrack>>(_builder.GetAlbumTracks(id, limit, offset, market));
+            return DownloadDataAsync<Paging<SimpleTrack>>(_builder.GetAlbumTracks(id, limit, offset, market));
         }
 
         /// <summary>
@@ -164,9 +164,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">The Spotify ID for the album.</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
-        public async Task<FullAlbum> GetAlbumAsync(string id, string market = "")
+        public Task<FullAlbum> GetAlbumAsync(string id, string market = "")
         {
-            return await DownloadDataAsync<FullAlbum>(_builder.GetAlbum(id, market));
+            return DownloadDataAsync<FullAlbum>(_builder.GetAlbum(id, market));
         }
 
         /// <summary>
@@ -186,9 +186,9 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of the Spotify IDs for the albums. Maximum: 20 IDs.</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
-        public async Task<SeveralAlbums> GetSeveralAlbumsAsync(List<string> ids, string market = "")
+        public Task<SeveralAlbums> GetSeveralAlbumsAsync(List<string> ids, string market = "")
         {
-            return await DownloadDataAsync<SeveralAlbums>(_builder.GetSeveralAlbums(ids, market));
+            return DownloadDataAsync<SeveralAlbums>(_builder.GetSeveralAlbums(ids, market));
         }
 
         #endregion Albums
@@ -210,9 +210,9 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <param name="id">The Spotify ID for the artist.</param>
         /// <returns></returns>
-        public async Task<FullArtist> GetArtistAsync(string id)
+        public Task<FullArtist> GetArtistAsync(string id)
         {
-            return await DownloadDataAsync<FullArtist>(_builder.GetArtist(id));
+            return DownloadDataAsync<FullArtist>(_builder.GetArtist(id));
         }
 
         /// <summary>
@@ -232,9 +232,9 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <param name="id">The Spotify ID for the artist.</param>
         /// <returns></returns>
-        public async Task<SeveralArtists> GetRelatedArtistsAsync(string id)
+        public Task<SeveralArtists> GetRelatedArtistsAsync(string id)
         {
-            return await DownloadDataAsync<SeveralArtists>(_builder.GetRelatedArtists(id));
+            return DownloadDataAsync<SeveralArtists>(_builder.GetRelatedArtists(id));
         }
 
         /// <summary>
@@ -254,9 +254,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">The Spotify ID for the artist.</param>
         /// <param name="country">The country: an ISO 3166-1 alpha-2 country code.</param>
         /// <returns></returns>
-        public async Task<SeveralTracks> GetArtistsTopTracksAsync(string id, string country)
+        public Task<SeveralTracks> GetArtistsTopTracksAsync(string id, string country)
         {
-            return await DownloadDataAsync<SeveralTracks>(_builder.GetArtistsTopTracks(id, country));
+            return DownloadDataAsync<SeveralTracks>(_builder.GetArtistsTopTracks(id, country));
         }
 
         /// <summary>
@@ -296,9 +296,9 @@ namespace SpotifyAPI.Web
         ///     geographical market
         /// </param>
         /// <returns></returns>
-        public async Task<Paging<SimpleAlbum>> GetArtistsAlbumsAsync(string id, AlbumType type = AlbumType.All, int limit = 20, int offset = 0, string market = "")
+        public Task<Paging<SimpleAlbum>> GetArtistsAlbumsAsync(string id, AlbumType type = AlbumType.All, int limit = 20, int offset = 0, string market = "")
         {
-            return await DownloadDataAsync<Paging<SimpleAlbum>>(_builder.GetArtistsAlbums(id, type, limit, offset, market));
+            return DownloadDataAsync<Paging<SimpleAlbum>>(_builder.GetArtistsAlbums(id, type, limit, offset, market));
         }
 
         /// <summary>
@@ -316,9 +316,9 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <param name="ids">A list of the Spotify IDs for the artists. Maximum: 50 IDs.</param>
         /// <returns></returns>
-        public async Task<SeveralArtists> GetSeveralArtistsAsync(List<string> ids)
+        public Task<SeveralArtists> GetSeveralArtistsAsync(List<string> ids)
         {
-            return await DownloadDataAsync<SeveralArtists>(_builder.GetSeveralArtists(ids));
+            return DownloadDataAsync<SeveralArtists>(_builder.GetSeveralArtists(ids));
         }
 
         #endregion Artists
@@ -356,11 +356,11 @@ namespace SpotifyAPI.Web
         /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
         /// <param name="offset">The index of the first item to return. Default: 0</param>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<FeaturedPlaylists> GetFeaturedPlaylistsAsync(string locale = "", string country = "", DateTime timestamp = default(DateTime), int limit = 20, int offset = 0)
+        public Task<FeaturedPlaylists> GetFeaturedPlaylistsAsync(string locale = "", string country = "", DateTime timestamp = default(DateTime), int limit = 20, int offset = 0)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetFeaturedPlaylists");
-            return await DownloadDataAsync<FeaturedPlaylists>(_builder.GetFeaturedPlaylists(locale, country, timestamp, limit, offset));
+            return DownloadDataAsync<FeaturedPlaylists>(_builder.GetFeaturedPlaylists(locale, country, timestamp, limit, offset));
         }
 
         /// <summary>
@@ -386,11 +386,11 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first item to return. Default: 0</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<NewAlbumReleases> GetNewAlbumReleasesAsync(string country = "", int limit = 20, int offset = 0)
+        public Task<NewAlbumReleases> GetNewAlbumReleasesAsync(string country = "", int limit = 20, int offset = 0)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetNewAlbumReleases");
-            return await DownloadDataAsync<NewAlbumReleases>(_builder.GetNewAlbumReleases(country, limit, offset));
+            return DownloadDataAsync<NewAlbumReleases>(_builder.GetNewAlbumReleases(country, limit, offset));
         }
 
         /// <summary>
@@ -430,11 +430,11 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first item to return. Default: 0 (the first object).</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<CategoryList> GetCategoriesAsync(string country = "", string locale = "", int limit = 20, int offset = 0)
+        public Task<CategoryList> GetCategoriesAsync(string country = "", string locale = "", int limit = 20, int offset = 0)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetCategories");
-            return await DownloadDataAsync<CategoryList>(_builder.GetCategories(country, locale, limit, offset));
+            return DownloadDataAsync<CategoryList>(_builder.GetCategories(country, locale, limit, offset));
         }
 
         /// <summary>
@@ -470,9 +470,9 @@ namespace SpotifyAPI.Web
         /// </param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Category> GetCategoryAsync(string categoryId, string country = "", string locale = "")
+        public Task<Category> GetCategoryAsync(string categoryId, string country = "", string locale = "")
         {
-            return await DownloadDataAsync<Category>(_builder.GetCategory(categoryId, country, locale));
+            return DownloadDataAsync<Category>(_builder.GetCategory(categoryId, country, locale));
         }
 
         /// <summary>
@@ -498,9 +498,9 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first item to return. Default: 0</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<CategoryPlaylist> GetCategoryPlaylistsAsync(string categoryId, string country = "", int limit = 20, int offset = 0)
+        public Task<CategoryPlaylist> GetCategoryPlaylistsAsync(string categoryId, string country = "", int limit = 20, int offset = 0)
         {
-            return await DownloadDataAsync<CategoryPlaylist>(_builder.GetCategoryPlaylists(categoryId, country, limit, offset));
+            return DownloadDataAsync<CategoryPlaylist>(_builder.GetCategoryPlaylists(categoryId, country, limit, offset));
         }
 
         /// <summary>
@@ -553,10 +553,10 @@ namespace SpotifyAPI.Web
         /// Because min_*, max_* and target_* are applied to pools before relinking, the generated results may not precisely match the filters applied.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Recommendations> GetRecommendationsAsync(List<string> artistSeed = null, List<string> genreSeed = null, List<string> trackSeed = null,
+        public Task<Recommendations> GetRecommendationsAsync(List<string> artistSeed = null, List<string> genreSeed = null, List<string> trackSeed = null,
             TuneableTrack target = null, TuneableTrack min = null, TuneableTrack max = null, int limit = 20, string market = "")
         {
-            return await DownloadDataAsync<Recommendations>(_builder.GetRecommendations(artistSeed, genreSeed, trackSeed, target, min, max, limit, market));
+            return DownloadDataAsync<Recommendations>(_builder.GetRecommendations(artistSeed, genreSeed, trackSeed, target, min, max, limit, market));
         }
 
         /// <summary>
@@ -574,9 +574,9 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<RecommendationSeedGenres> GetRecommendationSeedsGenresAsync()
+        public Task<RecommendationSeedGenres> GetRecommendationSeedsGenresAsync()
         {
-            return await DownloadDataAsync<RecommendationSeedGenres>(_builder.GetRecommendationSeedsGenres());
+            return DownloadDataAsync<RecommendationSeedGenres>(_builder.GetRecommendationSeedsGenres());
         }
 
         #endregion Browse
@@ -606,11 +606,11 @@ namespace SpotifyAPI.Web
         /// <param name="after">The last artist ID retrieved from the previous request.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<FollowedArtists> GetFollowedArtistsAsync(FollowType followType, int limit = 20, string after = "")
+        public Task<FollowedArtists> GetFollowedArtistsAsync(FollowType followType, int limit = 20, string after = "")
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetFollowedArtists");
-            return await DownloadDataAsync<FollowedArtists>(_builder.GetFollowedArtists(limit, after));
+            return DownloadDataAsync<FollowedArtists>(_builder.GetFollowedArtists(limit, after));
         }
 
         /// <summary>
@@ -642,9 +642,8 @@ namespace SpotifyAPI.Web
             {
                 {"ids", new JArray(ids)}
             };
-            return await 
-                UploadDataAsync<ErrorResponse>(_builder.Follow(followType),
-                    ob.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.Follow(followType),
+                    ob.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -666,9 +665,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">Artists or the Users Spotify ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> FollowAsync(FollowType followType, string id)
+        public Task<ErrorResponse> FollowAsync(FollowType followType, string id)
         {
-            return await FollowAsync(followType, new List<string> { id });
+            return FollowAsync(followType, new List<string> { id });
         }
 
         /// <summary>
@@ -700,7 +699,7 @@ namespace SpotifyAPI.Web
             {
                 {"ids", new JArray(ids)}
             };
-            return await UploadDataAsync<ErrorResponse>(_builder.Unfollow(followType), ob.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.Unfollow(followType), ob.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -722,9 +721,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">Artists or the Users Spotify ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> UnfollowAsync(FollowType followType, string id)
+        public Task<ErrorResponse> UnfollowAsync(FollowType followType, string id)
         {
-            return await UnfollowAsync(followType, new List<string> { id });
+            return UnfollowAsync(followType, new List<string> { id });
         }
 
         /// <summary>
@@ -752,13 +751,13 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of the artist or the user Spotify IDs to check</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, List<string> ids)
+        public Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, List<string> ids)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for IsFollowing");
 
             var url = _builder.IsFollowing(followType, ids);
-            return await DownloadListAsync<bool>(url);
+            return DownloadListAsync<bool>(url);
         }
 
         /// <summary>
@@ -780,9 +779,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">Artists or the Users Spotify ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, string id)
+        public Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, string id)
         {
-            return await IsFollowingAsync(followType, new List<string> { id });
+            return IsFollowingAsync(followType, new List<string> { id });
         }
 
         /// <summary>
@@ -822,13 +821,13 @@ namespace SpotifyAPI.Web
         /// </param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> FollowPlaylistAsync(string ownerId, string playlistId, bool showPublic = true)
+        public Task<ErrorResponse> FollowPlaylistAsync(string ownerId, string playlistId, bool showPublic = true)
         {
             JObject body = new JObject
             {
                 {"public", showPublic}
             };
-            return await UploadDataAsync<ErrorResponse>(_builder.FollowPlaylist(ownerId, playlistId, showPublic), body.ToString(Formatting.None), "PUT");
+            return UploadDataAsync<ErrorResponse>(_builder.FollowPlaylist(ownerId, playlistId, showPublic), body.ToString(Formatting.None), "PUT");
         }
 
         /// <summary>
@@ -850,9 +849,9 @@ namespace SpotifyAPI.Web
         /// <param name="playlistId">The Spotify ID of the playlist that is to be no longer followed.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> UnfollowPlaylistAsync(string ownerId, string playlistId)
+        public Task<ErrorResponse> UnfollowPlaylistAsync(string ownerId, string playlistId)
         {
-            return await UploadDataAsync<ErrorResponse>(_builder.UnfollowPlaylist(ownerId, playlistId), "", "DELETE");
+            return UploadDataAsync<ErrorResponse>(_builder.UnfollowPlaylist(ownerId, playlistId), "", "DELETE");
         }
 
         /// <summary>
@@ -880,13 +879,13 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of Spotify User IDs</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, List<string> ids)
+        public Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, List<string> ids)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for IsFollowingPlaylist");
 
             var url = _builder.IsFollowingPlaylist(ownerId, playlistId, ids);
-            return await DownloadListAsync<bool>(url);
+            return DownloadListAsync<bool>(url);
         }
 
         /// <summary>
@@ -910,9 +909,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">A Spotify User ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, string id)
+        public Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, string id)
         {
-            return await IsFollowingPlaylistAsync(ownerId, playlistId, new List<string> { id });
+            return IsFollowingPlaylistAsync(ownerId, playlistId, new List<string> { id });
         }
 
         #endregion Follow
@@ -940,7 +939,7 @@ namespace SpotifyAPI.Web
         public async Task<ErrorResponse> SaveTracksAsync(List<string> ids)
         {
             JArray array = new JArray(ids);
-            return await UploadDataAsync<ErrorResponse>(_builder.SaveTracks(), array.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.SaveTracks(), array.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -960,9 +959,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">A Spotify ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> SaveTrackAsync(string id)
+        public Task<ErrorResponse> SaveTrackAsync(string id)
         {
-            return await SaveTracksAsync(new List<string> { id });
+            return SaveTracksAsync(new List<string> { id });
         }
 
         /// <summary>
@@ -988,11 +987,11 @@ namespace SpotifyAPI.Web
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<SavedTrack>> GetSavedTracksAsync(int limit = 20, int offset = 0, string market = "")
+        public Task<Paging<SavedTrack>> GetSavedTracksAsync(int limit = 20, int offset = 0, string market = "")
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetSavedTracks");
-            return await DownloadDataAsync<Paging<SavedTrack>>(_builder.GetSavedTracks(limit, offset, market));
+            return DownloadDataAsync<Paging<SavedTrack>>(_builder.GetSavedTracks(limit, offset, market));
         }
 
         /// <summary>
@@ -1016,7 +1015,7 @@ namespace SpotifyAPI.Web
         public async Task<ErrorResponse> RemoveSavedTracksAsync(List<string> ids)
         {
             JArray array = new JArray(ids);
-            return await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedTracks(), array.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedTracks(), array.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1040,12 +1039,12 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of the Spotify IDs.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> CheckSavedTracksAsync(List<string> ids)
+        public Task<ListResponse<bool>> CheckSavedTracksAsync(List<string> ids)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for CheckSavedTracks");
             var url = _builder.CheckSavedTracks(ids);
-            return await DownloadListAsync<bool>(url);
+            return DownloadListAsync<bool>(url);
         }
 
         /// <summary>
@@ -1069,7 +1068,7 @@ namespace SpotifyAPI.Web
         public async Task<ErrorResponse> SaveAlbumsAsync(List<string> ids)
         {
             JArray array = new JArray(ids);
-            return await UploadDataAsync<ErrorResponse>(_builder.SaveAlbums(), array.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.SaveAlbums(), array.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1089,9 +1088,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">A Spotify ID</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> SaveAlbumAsync(string id)
+        public Task<ErrorResponse> SaveAlbumAsync(string id)
         {
-            return await SaveAlbumsAsync(new List<string> { id });
+            return SaveAlbumsAsync(new List<string> { id });
         }
 
         /// <summary>
@@ -1117,11 +1116,11 @@ namespace SpotifyAPI.Web
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<SavedAlbum>> GetSavedAlbumsAsync(int limit = 20, int offset = 0, string market = "")
+        public Task<Paging<SavedAlbum>> GetSavedAlbumsAsync(int limit = 20, int offset = 0, string market = "")
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetSavedAlbumsAsync");
-            return await DownloadDataAsync<Paging<SavedAlbum>>(_builder.GetSavedAlbums(limit, offset, market));
+            return DownloadDataAsync<Paging<SavedAlbum>>(_builder.GetSavedAlbums(limit, offset, market));
         }
 
         /// <summary>
@@ -1145,7 +1144,7 @@ namespace SpotifyAPI.Web
         public async Task<ErrorResponse> RemoveSavedAlbumsAsync(List<string> ids)
         {
             JArray array = new JArray(ids);
-            return await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedAlbums(), array.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedAlbums(), array.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1169,12 +1168,12 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of the Spotify IDs.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ListResponse<bool>> CheckSavedAlbumsAsync(List<string> ids)
+        public Task<ListResponse<bool>> CheckSavedAlbumsAsync(List<string> ids)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for CheckSavedAlbumsAsync");
             var url = _builder.CheckSavedAlbums(ids);
-            return await DownloadListAsync<bool>(url);
+            return DownloadListAsync<bool>(url);
         }
 
         #endregion Library
@@ -1206,9 +1205,9 @@ namespace SpotifyAPI.Web
         /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<FullTrack>> GetUsersTopTracksAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        public Task<Paging<FullTrack>> GetUsersTopTracksAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
         {
-            return await DownloadDataAsync<Paging<FullTrack>>(_builder.GetUsersTopTracks(timeRange, limit, offest));
+            return DownloadDataAsync<Paging<FullTrack>>(_builder.GetUsersTopTracks(timeRange, limit, offest));
         }
 
         /// <summary>
@@ -1236,9 +1235,9 @@ namespace SpotifyAPI.Web
         /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<FullArtist>> GetUsersTopArtistsAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        public Task<Paging<FullArtist>> GetUsersTopArtistsAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
         {
-            return await DownloadDataAsync<Paging<FullArtist>>(_builder.GetUsersTopArtists(timeRange, limit, offest));
+            return DownloadDataAsync<Paging<FullArtist>>(_builder.GetUsersTopArtists(timeRange, limit, offest));
         }
 
         #endregion
@@ -1268,11 +1267,11 @@ namespace SpotifyAPI.Web
         /// <param name="offset">The index of the first playlist to return. Default: 0 (the first object)</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<SimplePlaylist>> GetUserPlaylistsAsync(string userId, int limit = 20, int offset = 0)
+        public Task<Paging<SimplePlaylist>> GetUserPlaylistsAsync(string userId, int limit = 20, int offset = 0)
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetUserPlaylists");
-            return await DownloadDataAsync<Paging<SimplePlaylist>>(_builder.GetUserPlaylists(userId, limit, offset));
+            return DownloadDataAsync<Paging<SimplePlaylist>>(_builder.GetUserPlaylists(userId, limit, offset));
         }
 
         /// <summary>
@@ -1306,11 +1305,11 @@ namespace SpotifyAPI.Web
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<FullPlaylist> GetPlaylistAsync(string userId, string playlistId, string fields = "", string market = "")
+        public Task<FullPlaylist> GetPlaylistAsync(string userId, string playlistId, string fields = "", string market = "")
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetPlaylist");
-            return await DownloadDataAsync<FullPlaylist>(_builder.GetPlaylist(userId, playlistId, fields, market));
+            return DownloadDataAsync<FullPlaylist>(_builder.GetPlaylist(userId, playlistId, fields, market));
         }
 
         /// <summary>
@@ -1348,11 +1347,11 @@ namespace SpotifyAPI.Web
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Paging<PlaylistTrack>> GetPlaylistTracksAsync(string userId, string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
+        public Task<Paging<PlaylistTrack>> GetPlaylistTracksAsync(string userId, string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetPlaylistTracks");
-            return await DownloadDataAsync<Paging<PlaylistTrack>>(_builder.GetPlaylistTracks(userId, playlistId, fields, limit, offset, market));
+            return DownloadDataAsync<Paging<PlaylistTrack>>(_builder.GetPlaylistTracks(userId, playlistId, fields, limit, offset, market));
         }
 
         /// <summary>
@@ -1393,14 +1392,14 @@ namespace SpotifyAPI.Web
         /// </param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<FullPlaylist> CreatePlaylistAsync(string userId, string playlistName, bool isPublic = true)
+        public Task<FullPlaylist> CreatePlaylistAsync(string userId, string playlistName, bool isPublic = true)
         {
             JObject body = new JObject
             {
                 {"name", playlistName},
                 {"public", isPublic}
             };
-            return await UploadDataAsync<FullPlaylist>(_builder.CreatePlaylist(userId, playlistName, isPublic), body.ToString(Formatting.None));
+            return UploadDataAsync<FullPlaylist>(_builder.CreatePlaylist(userId, playlistName, isPublic), body.ToString(Formatting.None));
         }
 
         /// <summary>
@@ -1438,7 +1437,7 @@ namespace SpotifyAPI.Web
                 body.Add("name", newName);
             if (newPublic != null)
                 body.Add("public", newPublic);
-            return await UploadDataAsync<ErrorResponse>(_builder.UpdatePlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+            return (await UploadDataAsync<ErrorResponse>(_builder.UpdatePlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1474,7 +1473,7 @@ namespace SpotifyAPI.Web
             {
                 {"uris", new JArray(uris.Take(100))}
             };
-            return await UploadDataAsync<ErrorResponse>(_builder.ReplacePlaylistTracks(userId, playlistId), body.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+            return await (UploadDataAsync<ErrorResponse>(_builder.ReplacePlaylistTracks(userId, playlistId), body.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1514,7 +1513,7 @@ namespace SpotifyAPI.Web
             {
                 {"tracks", JArray.FromObject(uris.Take(100))}
             };
-            return await UploadDataAsync<ErrorResponse>(_builder.RemovePlaylistTracks(userId, playlistId, uris), body.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+            return await (UploadDataAsync<ErrorResponse>(_builder.RemovePlaylistTracks(userId, playlistId, uris), body.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1538,9 +1537,9 @@ namespace SpotifyAPI.Web
         /// <param name="uri">Spotify URI</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> RemovePlaylistTrackAsync(string userId, string playlistId, DeleteTrackUri uri)
+        public Task<ErrorResponse> RemovePlaylistTrackAsync(string userId, string playlistId, DeleteTrackUri uri)
         {
-            return await RemovePlaylistTracksAsync(userId, playlistId, new List<DeleteTrackUri> { uri });
+            return RemovePlaylistTracksAsync(userId, playlistId, new List<DeleteTrackUri> { uri });
         }
 
         /// <summary>
@@ -1576,7 +1575,7 @@ namespace SpotifyAPI.Web
             {
                 {"uris", JArray.FromObject(uris.Take(100))}
             };
-            return await UploadDataAsync<ErrorResponse>(_builder.AddPlaylistTracks(userId, playlistId, uris, position), body.ToString(Formatting.None)) ?? new ErrorResponse();
+            return await (UploadDataAsync<ErrorResponse>(_builder.AddPlaylistTracks(userId, playlistId, uris, position), body.ToString(Formatting.None)).ConfigureAwait(false)) ?? new ErrorResponse();
         }
 
         /// <summary>
@@ -1602,9 +1601,9 @@ namespace SpotifyAPI.Web
         /// <param name="position">The position to insert the tracks, a zero-based index</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<ErrorResponse> AddPlaylistTrackAsync(string userId, string playlistId, string uri, int? position = null)
+        public Task<ErrorResponse> AddPlaylistTrackAsync(string userId, string playlistId, string uri, int? position = null)
         {
-            return await AddPlaylistTracksAsync(userId, playlistId, new List<string> { uri }, position);
+            return AddPlaylistTracksAsync(userId, playlistId, new List<string> { uri }, position);
         }
 
         /// <summary>
@@ -1642,7 +1641,7 @@ namespace SpotifyAPI.Web
         /// <param name="snapshotId">The playlist's snapshot ID against which you want to make the changes.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<Snapshot> ReorderPlaylistAsync(string userId, string playlistId, int rangeStart, int insertBefore, int rangeLength = 1, string snapshotId = "")
+        public Task<Snapshot> ReorderPlaylistAsync(string userId, string playlistId, int rangeStart, int insertBefore, int rangeLength = 1, string snapshotId = "")
         {
             JObject body = new JObject
             {
@@ -1653,7 +1652,7 @@ namespace SpotifyAPI.Web
             };
             if (!string.IsNullOrEmpty(snapshotId))
                 body.Add("snapshot_id", snapshotId);
-            return await UploadDataAsync<Snapshot>(_builder.ReorderPlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT");
+            return UploadDataAsync<Snapshot>(_builder.ReorderPlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT");
         }
 
         #endregion Playlists
@@ -1677,11 +1676,11 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<PrivateProfile> GetPrivateProfileAsync()
+        public Task<PrivateProfile> GetPrivateProfileAsync()
         {
             if (!UseAuth)
                 throw new InvalidOperationException("Auth is required for GetPrivateProfile");
-            return await DownloadDataAsync<PrivateProfile>(_builder.GetPrivateProfile());
+            return DownloadDataAsync<PrivateProfile>(_builder.GetPrivateProfile());
         }
 
         /// <summary>
@@ -1699,9 +1698,9 @@ namespace SpotifyAPI.Web
         /// </summary>
         /// <param name="userId">The user's Spotify user ID.</param>
         /// <returns></returns>
-        public async Task<PublicProfile> GetPublicProfileAsync(string userId)
+        public Task<PublicProfile> GetPublicProfileAsync(string userId)
         {
-            return await DownloadDataAsync<PublicProfile>(_builder.GetPublicProfile(userId));
+            return DownloadDataAsync<PublicProfile>(_builder.GetPublicProfile(userId));
         }
 
         #endregion Profiles
@@ -1725,9 +1724,9 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
-        public async Task<SeveralTracks> GetSeveralTracksAsync(List<string> ids, string market = "")
+        public Task<SeveralTracks> GetSeveralTracksAsync(List<string> ids, string market = "")
         {
-            return await DownloadDataAsync<SeveralTracks>(_builder.GetSeveralTracks(ids, market));
+            return DownloadDataAsync<SeveralTracks>(_builder.GetSeveralTracks(ids, market));
         }
 
         /// <summary>
@@ -1747,9 +1746,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">The Spotify ID for the track.</param>
         /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
         /// <returns></returns>
-        public async Task<FullTrack> GetTrackAsync(string id, string market = "")
+        public Task<FullTrack> GetTrackAsync(string id, string market = "")
         {
-            return await DownloadDataAsync<FullTrack>(_builder.GetTrack(id, market));
+            return DownloadDataAsync<FullTrack>(_builder.GetTrack(id, market));
         }
 
         /// <summary>
@@ -1769,9 +1768,9 @@ namespace SpotifyAPI.Web
         /// <param name="id">The Spotify ID for the track.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<AudioFeatures> GetAudioFeaturesAsync(string id)
+        public Task<AudioFeatures> GetAudioFeaturesAsync(string id)
         {
-            return await DownloadDataAsync<AudioFeatures>(_builder.GetAudioFeatures(id));
+            return DownloadDataAsync<AudioFeatures>(_builder.GetAudioFeatures(id));
         }
 
         /// <summary>
@@ -1791,9 +1790,9 @@ namespace SpotifyAPI.Web
         /// <param name="ids">A list of Spotify Track-IDs. Maximum: 100 IDs.</param>
         /// <returns></returns>
         /// <remarks>AUTH NEEDED</remarks>
-        public async Task<SeveralAudioFeatures> GetSeveralAudioFeaturesAsync(List<string> ids)
+        public Task<SeveralAudioFeatures> GetSeveralAudioFeaturesAsync(List<string> ids)
         {
-            return await DownloadDataAsync<SeveralAudioFeatures>(_builder.GetSeveralAudioFeatures(ids));
+            return DownloadDataAsync<SeveralAudioFeatures>(_builder.GetSeveralAudioFeatures(ids));
         }
 
         #endregion Tracks
@@ -1812,16 +1811,16 @@ namespace SpotifyAPI.Web
             return GetNextPage<Paging<T>, T>(paging);
         }
 
-        public async Task<TOut> GetNextPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        public Task<TOut> GetNextPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
         {
             if (!paging.HasNextPage())
                 throw new InvalidOperationException("This Paging-Object has no Next-Page");
-            return await DownloadDataAsync<TOut>(paging.Next);
+            return DownloadDataAsync<TOut>(paging.Next);
         }
 
-        public async Task<Paging<T>> GetNextPageAsync<T>(Paging<T> paging)
+        public Task<Paging<T>> GetNextPageAsync<T>(Paging<T> paging)
         {
-            return await GetNextPageAsync<Paging<T>, T>(paging);
+            return GetNextPageAsync<Paging<T>, T>(paging);
         }
 
         public TOut GetPreviousPage<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
@@ -1836,16 +1835,16 @@ namespace SpotifyAPI.Web
             return GetPreviousPage<Paging<T>, T>(paging);
         }
 
-        public async Task<TOut> GetPreviousPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        public Task<TOut> GetPreviousPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
         {
             if (!paging.HasPreviousPage())
                 throw new InvalidOperationException("This Paging-Object has no Previous-Page");
-            return await DownloadDataAsync<TOut>(paging.Previous);
+            return DownloadDataAsync<TOut>(paging.Previous);
         }
 
-        public async Task<Paging<T>> GetPreviousPageAsync<T>(Paging<T> paging)
+        public Task<Paging<T>> GetPreviousPageAsync<T>(Paging<T> paging)
         {
-            return await GetPreviousPageAsync<Paging<T>, T>(paging);
+            return GetPreviousPageAsync<Paging<T>, T>(paging);
         }
 
         private ListResponse<T> DownloadList<T>(string url)
@@ -1877,8 +1876,8 @@ namespace SpotifyAPI.Web
             ListResponse<T> data = null;
             do
             {
-                if (data != null) { await Task.Delay(RetryAfter); }
-                Tuple<ResponseInfo, JToken> res = await DownloadDataAltAsync<JToken>(url);
+                if (data != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                Tuple<ResponseInfo, JToken> res = await DownloadDataAltAsync<JToken>(url).ConfigureAwait(false);
                 data = ExtractDataToListResponse<T>(res);
 
                 lastError = data.Error;
@@ -1953,8 +1952,8 @@ namespace SpotifyAPI.Web
                 WebClient.SetHeader("Authorization", TokenType + " " + AccessToken);
                 WebClient.SetHeader("Content-Type", "application/json");
 
-                if (response != null) { await Task.Delay(RetryAfter); }
-                response = await WebClient.UploadJsonAsync<T>(url, uploadData, method);
+                if (response != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                response = await WebClient.UploadJsonAsync<T>(url, uploadData, method).ConfigureAwait(false);
 
                 response.Item2.AddResponseInfo(response.Item1);
                 lastError = response.Item2.Error;
@@ -1996,8 +1995,8 @@ namespace SpotifyAPI.Web
             Tuple<ResponseInfo, T> response = null;
             do
             {
-                if (response != null) { await Task.Delay(RetryAfter); }
-                response = await DownloadDataAltAsync<T>(url);
+                if (response != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                response = await DownloadDataAltAsync<T>(url).ConfigureAwait(false);
 
                 response.Item2.AddResponseInfo(response.Item1);
                 lastError = response.Item2.Error;

--- a/SpotifyAPI/Web/SpotifyWebClient.cs
+++ b/SpotifyAPI/Web/SpotifyWebClient.cs
@@ -57,7 +57,7 @@ namespace SpotifyAPI.Web
             Tuple<ResponseInfo, string> response;
             try
             {
-                Tuple<ResponseInfo, byte[]> raw = await DownloadRawAsync(url);
+                Tuple<ResponseInfo, byte[]> raw = await DownloadRawAsync(url).ConfigureAwait(false);
                 response = new Tuple<ResponseInfo, string>(raw.Item1, raw.Item2.Length > 0 ? _encoding.GetString(raw.Item2) : "{}");
             }
             catch (WebException e)
@@ -91,7 +91,7 @@ namespace SpotifyAPI.Web
                 webClient.Encoding = _encoding;
                 webClient.Headers = _webClient.Headers;
 
-                byte[] data = await _webClient.DownloadDataTaskAsync(url);
+                byte[] data = await _webClient.DownloadDataTaskAsync(url).ConfigureAwait(false);
                 ResponseInfo info = new ResponseInfo()
                 {
                     Headers = webClient.ResponseHeaders
@@ -108,7 +108,7 @@ namespace SpotifyAPI.Web
 
         public async Task<Tuple<ResponseInfo, T>> DownloadJsonAsync<T>(string url)
         {
-            Tuple<ResponseInfo, string> response = await DownloadAsync(url);
+            Tuple<ResponseInfo, string> response = await DownloadAsync(url).ConfigureAwait(false);
             return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
         }
 
@@ -138,7 +138,7 @@ namespace SpotifyAPI.Web
             Tuple<ResponseInfo, string> response;
             try
             {
-                Tuple<ResponseInfo, byte[]> data = await UploadRawAsync(url, body, method);
+                Tuple<ResponseInfo, byte[]> data = await UploadRawAsync(url, body, method).ConfigureAwait(false);
                 response = new Tuple<ResponseInfo, string>(data.Item1, data.Item2.Length > 0 ? _encoding.GetString(data.Item2) : "{}");
             }
             catch (WebException e)
@@ -171,7 +171,7 @@ namespace SpotifyAPI.Web
                 webClient.Proxy = null;
                 webClient.Encoding = _encoding;
                 webClient.Headers = _webClient.Headers;
-                byte[] data = await _webClient.UploadDataTaskAsync(url, method, _encoding.GetBytes(body));
+                byte[] data = await _webClient.UploadDataTaskAsync(url, method, _encoding.GetBytes(body)).ConfigureAwait(false);
                 ResponseInfo info = new ResponseInfo
                 {
                     Headers = _webClient.ResponseHeaders
@@ -188,7 +188,7 @@ namespace SpotifyAPI.Web
 
         public async Task<Tuple<ResponseInfo, T>> UploadJsonAsync<T>(string url, string body, string method)
         {
-            Tuple<ResponseInfo, string> response = await UploadAsync(url, body, method);
+            Tuple<ResponseInfo, string> response = await UploadAsync(url, body, method).ConfigureAwait(false);
             return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
         }
 


### PR DESCRIPTION
Removed bunch of unnecessary async/await (*1) and added `.ConfigureAwait(false)` to all remaining awaits because we don't want to be capturing context :).

(1*): There's no point in awaiting a `Task<..>` when it's result is immediately (without any alteration) returned because you can just as well return the `Task<..>` itself. 

While these two approaches produce different IL (awaiting and immediately returning the result results in a state machine being created and whole bunch of other stuff) the signature of the method (that either returns or awaits the return) remains the same either way which means this is a non-breaking change.

//StackOverflow backing me up: http://stackoverflow.com/questions/19098143/what-is-the-purpose-of-return-await-in-c

(It's highly likely that JIT actually optimizes the await before return away but why have it there if it's completely unnecessary).