### PR TITLE
Async methods return Tasks instead of void.

### DIFF
--- a/SpotifyAPI/Local/RemoteHandler.cs
+++ b/SpotifyAPI/Local/RemoteHandler.cs
@@ -22,23 +22,23 @@ namespace SpotifyAPI.Local
             return !string.IsNullOrEmpty(CfidKey);
         }
 
-        internal async void SendPauseRequest()
+        internal async Task SendPauseRequest()
         {
             await QueryAsync("remote/pause.json?pause=true", true, true, -1);
         }
 
-        internal async void SendPlayRequest()
+        internal async Task SendPlayRequest()
         {
             await QueryAsync("remote/pause.json?pause=false", true, true, -1);
         }
 
-        internal async void SendPlayRequest(string url, string context = "")
+        internal async Task SendPlayRequest(string url, string context = "")
         {
             // TODO: instead of having an empty context, one way to fix the bug with the playback time beyond the length of a song would be to provide a 1-song context, and it would be fixed.
             await QueryAsync($"remote/play.json?uri={url}&context={context}", true, true, -1);
         }
 
-        internal async void SendQueueRequest(string url)
+        internal async Task SendQueueRequest(string url)
         {
             await QueryAsync("remote/play.json?uri=" + url + "?action=queue", true, true, -1);
         }


### PR DESCRIPTION
Just  a small refactoration :). Isn't a breaking change as it's on internal methods. 