### PR TITLE
Update WebApiFactory.cs redirect uri creation

### DIFF
--- a/SpotifyAPI/Web/Auth/WebApiFactory.cs
+++ b/SpotifyAPI/Web/Auth/WebApiFactory.cs
@@ -35,7 +35,7 @@ namespace SpotifyAPI.Web.Auth
         {
             var authentication = new ImplicitGrantAuth
             {
-                RedirectUri = $"{_redirectUrl}:{_listeningPort}",
+                RedirectUri = new UriBuilder(_redirectUrl) { Port = _listeningPort }.Uri.OriginalString.TrimEnd('/'),
                 ClientId = _clientId,
                 Scope = _scope,
                 State = _xss


### PR DESCRIPTION
This could fix the **ImplicitGrantAuth** for http paths without breaking anything. `TrimEnd` is there for when there is no path (the builder will add a `/` which will make the callback url invalid otherwise.

Could fix issue #150