### PR TITLE
Add Audio Track Analysis models and API endpoint

### DIFF
--- a/SpotifyAPI.Docs/docs/SpotifyWebAPI/tracks.md
+++ b/SpotifyAPI.Docs/docs/SpotifyWebAPI/tracks.md
@@ -38,3 +38,22 @@ Console.WriteLine(track.Name);
 ```
 
 ---
+##GetAudioAnalysis
+
+> Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+
+**Paramters**  
+
+|Name|Description|Example|
+|--------------|-------------------------|-------------------------|
+|id| The Spotify ID for the track. | `"6Y1CLPwYe7zvI8PJiWVz6T"`
+
+Returns a AudioAnalysis (currently lacking Spotify documentation)
+
+**Usage**  
+```cs
+AudioAnalysis analysis = _spotify.GetAudioAnalysis("6Y1CLPwYe7zvI8PJiWVz6T");
+Console.WriteLine(analysis.Meta.DetailedStatus);
+```
+
+---

--- a/SpotifyAPI.Docs/docs/SpotifyWebAPI/tracks.md
+++ b/SpotifyAPI.Docs/docs/SpotifyWebAPI/tracks.md
@@ -48,7 +48,7 @@ Console.WriteLine(track.Name);
 |--------------|-------------------------|-------------------------|
 |id| The Spotify ID for the track. | `"6Y1CLPwYe7zvI8PJiWVz6T"`
 
-Returns a AudioAnalysis (currently lacking Spotify documentation)
+Returns a AudioAnalysis. This object is currently lacking Spotify documentation but archived [EchoNest documentation](https://web.archive.org/web/20160528174915/http://developer.echonest.com/docs/v4/_static/AnalyzeDocumentation.pdf) is relevant.
 
 **Usage**  
 ```cs

--- a/SpotifyAPI/SpotifyAPI.csproj
+++ b/SpotifyAPI/SpotifyAPI.csproj
@@ -80,7 +80,13 @@
     <Compile Include="Web\Auth\ClientCredentialsAuth.cs" />
     <Compile Include="Web\Enums\FollowType.cs" />
     <Compile Include="Web\Auth\ImplicitGrantAuth.cs" />
+    <Compile Include="Web\Models\AnalysisSegment.cs" />
+    <Compile Include="Web\Models\AnalysisTimeSlice.cs" />
+    <Compile Include="Web\Models\AnalysisMeta.cs" />
+    <Compile Include="Web\Models\AnalysisSection.cs" />
+    <Compile Include="Web\Models\AnalysisTrack.cs" />
     <Compile Include="Web\Models\ArrayResponse.cs" />
+    <Compile Include="Web\Models\AudioAnalysis.cs" />
     <Compile Include="Web\Models\AudioFeatures.cs" />
     <Compile Include="Web\Models\AvailabeDevices.cs" />
     <Compile Include="Web\Models\BasicModel.cs" />

--- a/SpotifyAPI/Web/Models/AnalysisMeta.cs
+++ b/SpotifyAPI/Web/Models/AnalysisMeta.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisMeta
+    {
+        [JsonProperty("analyzer_platform")]
+        public string AnalyzerVersion { get; set; }
+
+        [JsonProperty("platform")]
+        public string Platform { get; set; }
+
+        [JsonProperty("status_code")]
+        public int StatusCode { get; set; }
+
+        [JsonProperty("detailed_status")]
+        public string DetailedStatus { get; set; }
+
+        [JsonProperty("timestamp")]
+        public long Timestamp { get; set; }
+
+        [JsonProperty("analysis_time")]
+        public double AnalysisTime { get; set; }
+
+        [JsonProperty("input_process")]
+        public string InputProcess { get; set; }
+    }
+}

--- a/SpotifyAPI/Web/Models/AnalysisSection.cs
+++ b/SpotifyAPI/Web/Models/AnalysisSection.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisSection
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+
+        [JsonProperty("loudness")]
+        public double Loudness { get; set; }
+
+        [JsonProperty("tempo")]
+        public double Tempo { get; set; }
+
+        [JsonProperty("tempo_confidence")]
+        public double TempoConfidence { get; set; }
+
+        [JsonProperty("key")]
+        public int Key { get; set; }
+
+        [JsonProperty("key_confidence")]
+        public double KeyConfidence { get; set; }
+
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+
+        [JsonProperty("mode_confidence")]
+        public double ModeConfidence { get; set; }
+
+        [JsonProperty("time_signature")]
+        public int TimeSignature { get; set; }
+
+        [JsonProperty("time_signature_confidence")]
+        public double TimeSignatureConfidence { get; set; }
+    }
+}

--- a/SpotifyAPI/Web/Models/AnalysisSegment.cs
+++ b/SpotifyAPI/Web/Models/AnalysisSegment.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisSegment
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+
+        [JsonProperty("loudness_start")]
+        public double LoudnessStart { get; set; }
+
+        [JsonProperty("loudness_max_time")]
+        public double LoudnessMaxTime { get; set; }
+
+        [JsonProperty("loudness_max")]
+        public double LoudnessMax { get; set; }
+
+        [JsonProperty("loudness_end")]
+        public double LoudnessEnd { get; set; }
+
+        [JsonProperty("pitches")]
+        public List<double> Pitches { get; set; }
+
+        [JsonProperty("timbre")]
+        public List<double> Timbre { get; set; }
+    }
+}

--- a/SpotifyAPI/Web/Models/AnalysisTimeSlice.cs
+++ b/SpotifyAPI/Web/Models/AnalysisTimeSlice.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisTimeSlice
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+    }
+}

--- a/SpotifyAPI/Web/Models/AnalysisTrack.cs
+++ b/SpotifyAPI/Web/Models/AnalysisTrack.cs
@@ -1,0 +1,86 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisTrack
+    {
+        [JsonProperty("num_samples")]
+        public int NumSamples { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("sample_md5")]
+        public string SampleMD5 { get; set; }
+
+        [JsonProperty("offset_seconds")]
+        public double OffsetSeconds { get; set; }
+
+        [JsonProperty("window_seconds")]
+        public double WindowSeconds { get; set; }
+
+        [JsonProperty("analysis_sample_rate")]
+        public int AnalysisSampleRate { get; set; }
+
+        [JsonProperty("analysis_channels")]
+        public int AnalysisChannels { get; set; }
+
+        [JsonProperty("end_of_fade_in")]
+        public double EndOfFadeIn { get; set; }
+
+        [JsonProperty("start_of_fade_out")]
+        public double StartOfFadeOut { get; set; }
+
+        [JsonProperty("loudness")]
+        public double Loudness { get; set; }
+
+        [JsonProperty("tempo")]
+        public double Tempo { get; set; }
+
+        [JsonProperty("tempo_confidence")]
+        public double TempoConfidence { get; set; }
+
+        [JsonProperty("time_signature")]
+        public double TimeSignature { get; set; }
+
+        [JsonProperty("time_signature_confidence")]
+        public double TimeSignatureConfidence { get; set; }
+
+        [JsonProperty("key")]
+        public int Key { get; set; }
+
+        [JsonProperty("key_confidence")]
+        public double KeyConfidence { get; set; }
+
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+
+        [JsonProperty("mode_confidence")]
+        public double ModeConfidence { get; set; }
+
+        [JsonProperty("codestring")]
+        public string Codestring { get; set; }
+
+        [JsonProperty("code_version")]
+        public double CodeVersion { get; set; }
+
+        [JsonProperty("echoprintstring")]
+        public string Echoprintstring { get; set; }
+
+        [JsonProperty("echoprint_version")]
+        public double EchoprintVersion { get; set; }
+
+        [JsonProperty("synchstring")]
+        public string Synchstring { get; set; }
+
+        [JsonProperty("synch_version")]
+        public double SynchVersion { get; set; }
+
+        [JsonProperty("rhythmstring")]
+        public string Rhythmstring { get; set; }
+
+        [JsonProperty("rhythm_version")]
+        public double RhythmVersion { get; set; }
+
+    }
+}

--- a/SpotifyAPI/Web/Models/AudioAnalysis.cs
+++ b/SpotifyAPI/Web/Models/AudioAnalysis.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AudioAnalysis : BasicModel
+    {
+        [JsonProperty("bars")]
+        public List<AnalysisTimeSlice> Bars { get; set; }
+
+        [JsonProperty("beats")]
+        public List<AnalysisTimeSlice> Beats { get; set; }
+
+        [JsonProperty("meta")]
+        public AnalysisMeta Meta { get; set; }
+
+        [JsonProperty("sections")]
+        public List<AnalysisSection> Sections { get; set; }
+
+        [JsonProperty("segments")]
+        public List<AnalysisSegment> Segments { get; set; }
+
+        [JsonProperty("tatums")]
+        public List<AnalysisTimeSlice> Tatums { get; set; }
+
+        [JsonProperty("track")]
+        public AnalysisTrack Track { get; set; }
+    }
+}

--- a/SpotifyAPI/Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI/Web/SpotifyWebAPI.cs
@@ -1781,6 +1781,28 @@ namespace SpotifyAPI.Web
         }
 
         /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public AudioAnalysis GetAudioAnalysis(string id)
+        {
+            return DownloadData<AudioAnalysis>(_builder.GetAudioAnalysis(id));
+        }
+
+        /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<AudioAnalysis> GetAudioAnalysisAsync(string id)
+        {
+            return DownloadDataAsync<AudioAnalysis>(_builder.GetAudioAnalysis(id));
+        }
+
+        /// <summary>
         ///     Get audio feature information for a single track identified by its unique Spotify ID.
         /// </summary>
         /// <param name="id">The Spotify ID for the track.</param>

--- a/SpotifyAPI/Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI/Web/SpotifyWebBuilder.cs
@@ -818,6 +818,17 @@ namespace SpotifyAPI.Web
         }
 
         /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetAudioAnalysis(string id)
+        {
+            return $"{APIBase}/audio-analysis/{id}";
+        }
+
+        /// <summary>
         ///     Get audio feature information for a single track identified by its unique Spotify ID.
         /// </summary>
         /// <param name="id">The Spotify ID for the track.</param>


### PR DESCRIPTION
I am looking to utilize the Track Audio Analysis API endpoint from Spotify and noticed it was missing from the library.