### PR TITLE
 Refactored SpotifyUri Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ TestResults
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/SpotifyAPI.Tests/SpotifyAPI.Tests.csproj
+++ b/SpotifyAPI.Tests/SpotifyAPI.Tests.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SpotifyUriTest.cs" />
     <Compile Include="TestClass.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -66,6 +67,9 @@
     <None Include="fixtures\private-user.json" />
     <None Include="fixtures\public-user.json" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/SpotifyAPI.Tests/SpotifyAPI.Tests.csproj
+++ b/SpotifyAPI.Tests/SpotifyAPI.Tests.csproj
@@ -32,19 +32,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.7.145.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.145\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5797.27534, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/SpotifyAPI.Tests/SpotifyUriTest.cs
+++ b/SpotifyAPI.Tests/SpotifyUriTest.cs
@@ -1,0 +1,59 @@
+﻿using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SpotifyAPI.Local;
+using SpotifyAPI.Local.Models;
+using SpotifyAPI.Local.Enums;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SpotifyAPI.Tests
+{
+    public class SpotifyUriTest
+    {
+        [Test]
+        public void ShouldThrowArgumentExceptionForInvalidUri()
+        {
+            Assert.Throws<ArgumentException>(() => SpotifyUri.Parse("asdafadfgsrsegqejfa"));
+        }
+
+        [Test]
+        public void ShouldCorrectlyParseTrackUri()
+        {
+            string testUri = "spotify:track:3QOruXa2lvqIFvOOa2rYyJ";
+            SpotifyUri uri = SpotifyUri.Parse(testUri);
+
+            Assert.AreEqual(uri.Base, "spotify");
+
+            Assert.AreEqual(uri.Type, UriType.track);
+            Assert.AreEqual(uri.Id, "3QOruXa2lvqIFvOOa2rYyJ");
+            Assert.AreEqual(uri.ToString(), testUri);
+        }
+
+        [Test]
+        public void ShouldCorrectlyParsePlaylistUri()
+        {
+            string testUri = "spotify:user:spotifycharts:playlist:37i9dQZEVXbMDoHDwVN2tF";
+            SpotifyUri uri = SpotifyUri.Parse(testUri);
+
+            Assert.AreEqual(uri.Base, "spotify");
+
+            Assert.AreEqual(uri.Type, UriType.playlist);
+            Assert.AreEqual(uri.Id, "37i9dQZEVXbMDoHDwVN2tF");
+
+            Assert.AreEqual(uri.GetUriPropValue(UriType.user), "spotifycharts");
+            Assert.AreEqual(uri.ToString(), testUri);
+        }
+
+        [Test]
+        public void ShouldHandleNotExistingUriProperty()
+        {
+            string testUri = "spotify:track:3QOruXa2lvqIFvOOa2rYyJ";
+            SpotifyUri uri = SpotifyUri.Parse(testUri);
+            Assert.DoesNotThrow(() => uri.GetUriPropValue(UriType.user));
+            Assert.IsNull(uri.GetUriPropValue(UriType.user));
+        }
+    }
+}

--- a/SpotifyAPI.Tests/packages.config
+++ b/SpotifyAPI.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="NUnit" version="3.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
+  <package id="Moq" version="4.7.145" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
 </packages>

--- a/SpotifyAPI/Local/Enums/UriType.cs
+++ b/SpotifyAPI/Local/Enums/UriType.cs
@@ -1,0 +1,12 @@
+﻿namespace SpotifyAPI.Local.Enums
+{
+    public enum UriType
+    {
+        none,
+        track,
+        album,
+        artist,
+        playlist,
+        user
+    }
+}

--- a/SpotifyAPI/Local/Models/SpotifyUri.cs
+++ b/SpotifyAPI/Local/Models/SpotifyUri.cs
@@ -39,15 +39,17 @@ namespace SpotifyAPI.Local.Models
             if (string.IsNullOrEmpty(uri))
                 throw new ArgumentNullException("Uri");
 
+            UriType uriType = UriType.none;
             string[] props = uri.Split(':');
-            if (props.Length < 3 || !Enum.TryParse(props[1], out UriType uriType))
+            if (props.Length < 3 || !Enum.TryParse(props[1], out uriType))
                 throw new ArgumentException("Unexpected Uri");
 
             Dictionary<UriType, string> properties = new Dictionary<UriType, string> { { uriType, props[2] } };
 
             for (int index = 3; index < props.Length; index += 2)
             {
-                if (Enum.TryParse(props[index], out UriType type))
+                UriType type = UriType.none;
+                if (Enum.TryParse(props[index], out type))
                     properties.Add(type, props[index + 1]);
             }
 

--- a/SpotifyAPI/SpotifyAPI.csproj
+++ b/SpotifyAPI/SpotifyAPI.csproj
@@ -37,9 +37,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -55,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Local\Enums\UriType.cs" />
     <Compile Include="Local\ExtendedWebClient.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/SpotifyAPI/SpotifyAPI.csproj
+++ b/SpotifyAPI/SpotifyAPI.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/SpotifyAPI/packages.config
+++ b/SpotifyAPI/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is a refactored version of the SpotifyUri class. The old implementation did work with most URI's but not with all variations (e.g. playlists).

Tested with the following URI configurations:
spotify:track:[id]
spotify:artist:[id]
spotify:album:[id]
spotify:user:[id]
spotify:user:[id]:playlist:[id]