### PR TITLE
Raise OnTrackChange event for "other" tracks as well

### DIFF
--- a/SpotifyAPI.Example/LocalControl.cs
+++ b/SpotifyAPI.Example/LocalControl.cs
@@ -84,21 +84,21 @@ namespace SpotifyAPI.Example
             if (track.IsAd())
                 return; //Don't process further, maybe null values
 
-            titleLinkLabel.Text = track.TrackResource.Name;
-            titleLinkLabel.Tag = track.TrackResource.Uri;
+            titleLinkLabel.Text = track.TrackResource?.Name;
+            titleLinkLabel.Tag = track.TrackResource?.Uri;
 
-            artistLinkLabel.Text = track.ArtistResource.Name;
-            artistLinkLabel.Tag = track.ArtistResource.Uri;
+            artistLinkLabel.Text = track.ArtistResource?.Name;
+            artistLinkLabel.Tag = track.ArtistResource?.Uri;
 
-            albumLinkLabel.Text = track.AlbumResource.Name;
-            albumLinkLabel.Tag = track.AlbumResource.Uri;
+            albumLinkLabel.Text = track.AlbumResource?.Name;
+            albumLinkLabel.Tag = track.AlbumResource?.Uri;
 
-            SpotifyUri uri = track.TrackResource.ParseUri();
+            SpotifyUri uri = track.TrackResource?.ParseUri();
 
-            trackInfoBox.Text = $@"Track Info - {uri.Id}";
+            trackInfoBox.Text = $@"Track Info - {uri?.Id}";
 
-            bigAlbumPicture.Image = await track.GetAlbumArtAsync(AlbumArtSize.Size640);
-            smallAlbumPicture.Image = await track.GetAlbumArtAsync(AlbumArtSize.Size160);
+            bigAlbumPicture.Image = track.AlbumResource != null ? await track.GetAlbumArtAsync(AlbumArtSize.Size640) : null;
+            smallAlbumPicture.Image = track.AlbumResource != null ? await track.GetAlbumArtAsync(AlbumArtSize.Size160) : null;
         }
 
         public void UpdatePlayingStatus(bool playing)

--- a/SpotifyAPI/Local/Models/Track.cs
+++ b/SpotifyAPI/Local/Models/Track.cs
@@ -38,6 +38,15 @@ namespace SpotifyAPI.Local.Models
                 return true;
             return false;
         }
+        
+        /// <summary>
+        /// Checks if the track id of type "other"
+        /// </summary>
+        /// <returns>true if the track is neither an advert nor a normal track, for example a podcast</returns>
+        public bool IsOtherTrackType()
+        {
+            return TrackType == "other";
+        }
 
         /// <summary>
         /// Returns a URL to the album cover in the provided size

--- a/SpotifyAPI/Local/SpotifyLocalAPI.cs
+++ b/SpotifyAPI/Local/SpotifyLocalAPI.cs
@@ -107,7 +107,8 @@ namespace SpotifyAPI.Local
             }
             if (newStatusResponse.Track != null && _eventStatusResponse.Track != null)
             {
-                if (newStatusResponse.Track.TrackResource?.Uri != _eventStatusResponse.Track.TrackResource?.Uri)
+                if (newStatusResponse.Track.TrackResource?.Uri != _eventStatusResponse.Track.TrackResource?.Uri ||
+                    newStatusResponse.Track.IsOtherTrackType() && newStatusResponse.Track.Length != this._eventStatusResponse.Track.Length)
                 {
                     OnTrackChange?.Invoke(this, new TrackChangeEventArgs()
                     {


### PR DESCRIPTION
I was trying out the local APIs with some podcasts and noticed that the `OnTrackChange` event was never raised, except when switching from a normal track to a podcast or vice versa.
I found out that podcasts don't seem to be currently supported by the APIs (neither by the local ones nor by the official web APIs), so when a podcast is playing the track object's fields are all null except for `TrackType` and `Length`.