### PR TITLE
added SnapshotId to FullPlaylist

### DIFF
--- a/SpotifyAPI/Web/Models/FullPlaylist.cs
+++ b/SpotifyAPI/Web/Models/FullPlaylist.cs
@@ -36,6 +36,9 @@ namespace SpotifyAPI.Web.Models
         [JsonProperty("public")]
         public Boolean Public { get; set; }
 
+        [JsonProperty("snapshot_id")]
+        public string SnapshotId { get; set; }
+
         [JsonProperty("tracks")]
         public Paging<PlaylistTrack> Tracks { get; set; }
 


### PR DESCRIPTION
This adds the SnapshotId field to FullPlaylist as discussed in #226.

I couldn't find a test checking the properties (did I miss something?), so I just tested it in an own project, with success:
```
Old snapshot: L1kNFQwnhUdTgFYPnfaL+gwOW+J819KbEopRq4igVy/fuyr1NKXdYLL5TY5/Y8h+  
New snapshot: aETRK3Xj+MzeAjRbHJV0n+XyXalQHrsrBE5bH+G8cYUyhU5UDQWNKFAelJ0YLgJo
```