### PR TITLE
Fixed Util.cs ToUnixTimeMillisecondsPoly() decimal point

### DIFF
--- a/SpotifyAPI/Web/Util.cs
+++ b/SpotifyAPI/Web/Util.cs
@@ -23,9 +23,9 @@ namespace SpotifyAPI.Web
             return string.Join(separator, list);
         }
 
-        public static double ToUnixTimeMillisecondsPoly(this DateTime time)
+        public static long ToUnixTimeMillisecondsPoly(this DateTime time)
         {
-            return time.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+            return (long)time.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
         }
     }
 


### PR DESCRIPTION
Fixed ToUnixTimeMillisecondsPoly() to return a long, since decimal point breaks before/after paging.

This could be a breaking change, since the extension method is public. If this potentially breaking change is undesirable, we can keep the method signature.