### PR TITLE
Update Newtonsoft.Json dependency version

### DIFF
--- a/SpotifyAPI/SpotifyAPI.nuspec
+++ b/SpotifyAPI/SpotifyAPI.nuspec
@@ -15,7 +15,7 @@ For more infos, visit https://github.com/JohnnyCrazy/SpotifyAPI-NET</description
         <language />
         <tags>spotify api music .net c# spotify-client</tags>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="8.0.2" />
+            <dependency id="Newtonsoft.Json" version="10.0.3" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
This PR updates the version in the .nuspec to match with the current dependency.
It will prevent users from encountering a FileLoadException (#228) due to v8.0.2 being installed, and any confusion with the required version.