### PR TITLE
Added SpotifyAPI.Core - .NET Core version of SpotifyAPI

### DIFF
--- a/SpotifyAPI.Core/Local/Enums/AlbumArtSize.cs
+++ b/SpotifyAPI.Core/Local/Enums/AlbumArtSize.cs
@@ -1,0 +1,9 @@
+﻿namespace SpotifyAPI.Local.Enums
+{
+    public enum AlbumArtSize
+    {
+        Size160,
+        Size320,
+        Size640
+    }
+}

--- a/SpotifyAPI.Core/Local/Enums/UriType.cs
+++ b/SpotifyAPI.Core/Local/Enums/UriType.cs
@@ -1,0 +1,12 @@
+﻿namespace SpotifyAPI.Local.Enums
+{
+    public enum UriType
+    {
+        none,
+        track,
+        album,
+        artist,
+        playlist,
+        user
+    }
+}

--- a/SpotifyAPI.Core/Local/ExtendedWebClient.cs
+++ b/SpotifyAPI.Core/Local/ExtendedWebClient.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net;
+using System.Text;
+
+namespace SpotifyAPI.Local
+{
+    internal class ExtendedWebClient : WebClient
+    {
+        public int Timeout { get; set; }
+
+        public ExtendedWebClient()
+        {
+            // TODO Remove once SSL Issues are resolved #115
+            ServicePointManager.ServerCertificateValidationCallback = (s, certificate, chain, sslPolicyErrors) => true;
+            Encoding = Encoding.UTF8;
+            Timeout = 2000;
+            Headers.Add("Origin", "https://embed.spotify.com");
+            Headers.Add("Referer", "https://embed.spotify.com/?uri=spotify:track:5Zp4SWOpbuOdnsxLqwgutt");
+        }
+
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            WebRequest webRequest = base.GetWebRequest(address);
+            if (webRequest != null)
+                webRequest.Timeout = Timeout;
+            return webRequest;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/LocalEvents.cs
+++ b/SpotifyAPI.Core/Local/LocalEvents.cs
@@ -1,0 +1,39 @@
+﻿using SpotifyAPI.Local.Models;
+using System;
+
+namespace SpotifyAPI.Local
+{
+    /// <summary>
+    /// Event gets triggered, when the Track is changed
+    /// </summary>
+    public class TrackChangeEventArgs
+    {
+        public Track OldTrack { get; set; }
+        public Track NewTrack { get; set; }
+    }
+
+    /// <summary>
+    /// Event gets triggered, when the Playin-state is changed (e.g Play --> Pause)
+    /// </summary>
+    public class PlayStateEventArgs
+    {
+        public Boolean Playing { get; set; }
+    }
+
+    /// <summary>
+    /// Event gets triggered, when the volume changes
+    /// </summary>
+    public class VolumeChangeEventArgs
+    {
+        public double OldVolume { get; set; }
+        public double NewVolume { get; set; }
+    }
+
+    /// <summary>
+    /// Event gets triggered, when the tracktime changes
+    /// </summary>
+    public class TrackTimeChangeEventArgs
+    {
+        public double TrackTime { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/CFID.cs
+++ b/SpotifyAPI.Core/Local/Models/CFID.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace SpotifyAPI.Local.Models
+{
+    /// <summary>
+    /// JSON Response, used internaly
+    /// </summary>
+    internal class Cfid
+    {
+        public Error Error { get; set; }
+        public string Token { get; set; }
+        public string Version { get; set; }
+        public string ClientVersion { get; set; }
+        public Boolean Running { get; set; }
+    }
+
+    /// <summary>
+    /// JSON Response, used internaly
+    /// </summary>
+    internal class Error
+    {
+        public string Type { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/OpenGraphState.cs
+++ b/SpotifyAPI.Core/Local/Models/OpenGraphState.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class OpenGraphState
+    {
+        [JsonProperty("private_session")]
+        public Boolean PrivateSession { get; set; }
+
+        [JsonProperty("posting_disabled")]
+        public Boolean PostingDisabled { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/SpotifyResource.cs
+++ b/SpotifyAPI.Core/Local/Models/SpotifyResource.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class SpotifyResource
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("location")]
+        public TrackResourceLocation Location { get; set; }
+
+        public SpotifyUri ParseUri()
+        {
+            return SpotifyUri.Parse(Uri);
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/SpotifyUri.cs
+++ b/SpotifyAPI.Core/Local/Models/SpotifyUri.cs
@@ -1,0 +1,60 @@
+﻿using SpotifyAPI.Local.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class SpotifyUri
+    {
+        private readonly Dictionary<UriType, string> _properties = new Dictionary<UriType, string>();
+
+        public string Base { get; }
+        public UriType Type => _properties?.LastOrDefault().Key ?? UriType.none;
+        public string Id => _properties?.LastOrDefault().Value;
+
+        public SpotifyUri(string uriBase, Dictionary<UriType, string> properties)
+        {
+            Base = uriBase;
+            _properties = properties;
+        }
+
+        public SpotifyUri(string uriBase, UriType uriType, string uriId)
+        {
+            Base = uriBase;
+            _properties.Add(uriType, uriId);
+        }
+
+        public string GetUriPropValue(UriType type)
+        {
+            return !_properties.ContainsKey(type) ? null : _properties[type];
+        }
+
+        public static SpotifyUri Parse(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+                throw new ArgumentNullException("Uri");
+
+            string[] props = uri.Split(':');
+            if (props.Length < 3 || !Enum.TryParse(props[1], out UriType uriType))
+                throw new ArgumentException("Unexpected Uri");
+
+            Dictionary<UriType, string> properties = new Dictionary<UriType, string> { { uriType, props[2] } };
+
+            for (int index = 3; index < props.Length; index += 2)
+            {
+                if (Enum.TryParse(props[index], out UriType type))
+                    properties.Add(type, props[index + 1]);
+            }
+
+            return new SpotifyUri(props[0], properties);
+        }
+
+        public override string ToString()
+        {
+            return $"{Base}:{string.Join(":", _properties.SelectMany(x => new[] { x.Key.ToString(), x.Value }))}";
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/StatusResponse.cs
+++ b/SpotifyAPI.Core/Local/Models/StatusResponse.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class StatusResponse
+    {
+        [JsonProperty("version")]
+        public int Version { get; set; }
+
+        [JsonProperty("client_version")]
+        public string ClientVersion { get; set; }
+
+        [JsonProperty("playing")]
+        public bool Playing { get; set; }
+
+        [JsonProperty("shuffle")]
+        public bool Shuffle { get; set; }
+
+        [JsonProperty("repeat")]
+        public bool Repeat { get; set; }
+
+        [JsonProperty("play_enabled")]
+        public bool PlayEnabled { get; set; }
+
+        [JsonProperty("prev_enabled")]
+        public bool PrevEnabled { get; set; }
+
+        [JsonProperty("next_enabled")]
+        public bool NextEnabled { get; set; }
+
+        [JsonProperty("track")]
+        public Track Track { get; set; }
+
+        [JsonProperty("playing_position")]
+        public double PlayingPosition { get; set; }
+
+        [JsonProperty("server_time")]
+        public int ServerTime { get; set; }
+
+        [JsonProperty("volume")]
+        public double Volume { get; set; }
+
+        [JsonProperty("online")]
+        public bool Online { get; set; }
+
+        [JsonProperty("open_graph_state")]
+        public OpenGraphState OpenGraphState { get; set; }
+
+        [JsonProperty("running")]
+        public bool Running { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/Track.cs
+++ b/SpotifyAPI.Core/Local/Models/Track.cs
@@ -1,0 +1,188 @@
+﻿using Newtonsoft.Json;
+using SpotifyAPI.Local.Enums;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class Track
+    {
+        [JsonProperty("track_resource")]
+        public SpotifyResource TrackResource { get; set; }
+
+        [JsonProperty("artist_resource")]
+        public SpotifyResource ArtistResource { get; set; }
+
+        [JsonProperty("album_resource")]
+        public SpotifyResource AlbumResource { get; set; }
+
+        [JsonProperty("length")]
+        public int Length { get; set; }
+
+        [JsonProperty("track_type")]
+        public string TrackType { get; set; }
+
+        /// <summary>
+        /// Checks if the track is an advert
+        /// </summary>
+        /// <returns>true if the track is an advert, false otherwise</returns>
+        public bool IsAd()
+        {
+            if (TrackType == "ad")
+                return true;
+            if (Length == 0)
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the track id of type "other"
+        /// </summary>
+        /// <returns>true if the track is neither an advert nor a normal track, for example a podcast</returns>
+        public bool IsOtherTrackType()
+        {
+            return TrackType == "other";
+        }
+
+        /// <summary>
+        /// Returns a URL to the album cover in the provided size
+        /// </summary>
+        /// <param name="size">AlbumArtSize (160,320,640)</param>
+        /// <param name="proxyConfig">Optional proxy settings</param>
+        /// <returns>A String, which is the URL to the Albumart</returns>
+        public string GetAlbumArtUrl(AlbumArtSize size, ProxyConfig proxyConfig = null)
+        {
+            return GetAlbumArtUrl(size, proxyConfig?.CreateWebProxy());
+        }
+
+        private string GetAlbumArtUrl(AlbumArtSize size, IWebProxy proxy = null)
+        {
+            if (AlbumResource.Uri == null || !AlbumResource.Uri.Contains("spotify:album:") || AlbumResource.Uri.Contains("spotify:album:0000000000000000000000"))
+                return "";
+
+            int albumsize = 0;
+            switch (size)
+            {
+                case AlbumArtSize.Size160:
+                    albumsize = 160;
+                    break;
+
+                case AlbumArtSize.Size320:
+                    albumsize = 320;
+                    break;
+
+                case AlbumArtSize.Size640:
+                    albumsize = 640;
+                    break;
+            }
+            string raw;
+            using (WebClient wc = new WebClient())
+            {
+                wc.Proxy = proxy;
+                wc.Headers.Add(HttpRequestHeader.UserAgent, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+                raw = wc.DownloadString("http://open.spotify.com/album/" + AlbumResource.Uri.Split(new[] { ":" }, StringSplitOptions.None)[2]);
+            }
+            raw = raw.Replace("\t", "");
+
+            // <img id="cover-img" src="https://d3rt1990lpmkn.cloudfront.net/640/e62a04cfea4122961f3b9159493730c27d61f71b" ...
+            string[] lines = raw.Split(new[] { "\n" }, StringSplitOptions.None);
+            const string pattern = "id=\"cover-img\".*?src=\"(.*?)\"";
+            Regex rgx = new Regex(pattern, RegexOptions.IgnoreCase);
+            foreach (string line in lines)
+            {
+                MatchCollection matches = rgx.Matches(line);
+                if (matches.Count > 0)
+                {
+                    string content = matches[0].Groups[1].Value;
+                    string[] l = content.Split(new[] { "/" }, StringSplitOptions.None);
+                    return "http://o.scdn.co/" + albumsize + @"/" + l[4];
+                }
+            }
+            return "";
+        }
+
+        /// <summary>
+        /// Returns a Bitmap of the album cover in the provided size asynchronous
+        /// </summary>
+        /// <param name="size">AlbumArtSize (160,320,640)</param>
+        /// <param name="proxyConfig">Optional proxy settings</param>
+        /// <returns>A Bitmap, which is the albumart</returns>
+        public async Task<Bitmap> GetAlbumArtAsync(AlbumArtSize size, ProxyConfig proxyConfig = null)
+        {
+            var data = await GetAlbumArtAsByteArrayAsync(size, proxyConfig).ConfigureAwait(false);
+            if (data != null)
+            {
+                using (MemoryStream ms = new MemoryStream(data))
+                {
+                    return (Bitmap)Image.FromStream(ms);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a byte[] of the the album cover in the provided size asynchronous
+        /// </summary>
+        /// <param name="size">AlbumArtSize (160,320,640)</param>
+        /// <param name="proxyConfig">Optional proxy settings</param>
+        /// <returns>A byte[], which is the albumart in binary data</returns>
+        public Task<byte[]> GetAlbumArtAsByteArrayAsync(AlbumArtSize size, ProxyConfig proxyConfig = null)
+        {
+            using (WebClient wc = new WebClient())
+            {
+                IWebProxy proxy = proxyConfig?.CreateWebProxy();
+                wc.Proxy = proxy;
+
+                string url = GetAlbumArtUrl(size, proxy);
+                if (url == "")
+                    return null;
+                return wc.DownloadDataTaskAsync(url);
+            }
+        }
+
+        /// <summary>
+        /// Returns a Bitmap of the album cover in the provided size
+        /// </summary>
+        /// <param name="size">AlbumArtSize (160,320,640)</param>
+        /// <param name="proxyConfig">Optional proxy settings</param>
+        /// <returns>A Bitmap, which is the albumart</returns>
+        public Bitmap GetAlbumArt(AlbumArtSize size, ProxyConfig proxyConfig = null)
+        {
+            var data = GetAlbumArtAsByteArray(size, proxyConfig);
+            if (data != null)
+            {
+                using (MemoryStream ms = new MemoryStream(data))
+                {
+                    return (Bitmap)Image.FromStream(ms);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a byte[] of the album cover in the provided size
+        /// </summary>
+        /// <param name="size">AlbumArtSize (160,320,640)</param>
+        /// <param name="proxyConfig">Optional proxy settings</param>
+        /// <returns>A byte[], which is the albumart in binary data</returns>
+        public byte[] GetAlbumArtAsByteArray(AlbumArtSize size, ProxyConfig proxyConfig = null)
+        {
+            using (WebClient wc = new WebClient())
+            {
+                IWebProxy proxy = proxyConfig?.CreateWebProxy();
+                wc.Proxy = proxy;
+
+                string url = GetAlbumArtUrl(size, proxy);
+                if (string.IsNullOrEmpty(url))
+                    return null;
+                return wc.DownloadData(url);
+            }
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/Models/TrackResourceLocation.cs
+++ b/SpotifyAPI.Core/Local/Models/TrackResourceLocation.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Local.Models
+{
+    public class TrackResourceLocation
+    {
+        [JsonProperty("og")]
+        public string Og { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/RemoteHandler.cs
+++ b/SpotifyAPI.Core/Local/RemoteHandler.cs
@@ -1,0 +1,194 @@
+﻿using Newtonsoft.Json;
+using SpotifyAPI.Local.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Web;
+
+[assembly: InternalsVisibleTo("SpotifyAPI.Tests")]
+
+
+namespace SpotifyAPI.Local
+{
+
+    internal class RemoteHandler
+    {
+        public string OauthKey { get; private set; }
+        public string CfidKey { get; private set; }
+
+        private SpotifyLocalAPIConfig _config;
+
+        public RemoteHandler(SpotifyLocalAPIConfig config)
+        {
+            _config = config;
+        }
+
+        internal bool Init()
+        {
+            OauthKey = GetOAuthKey();
+            CfidKey = GetCfid();
+            return !string.IsNullOrEmpty(CfidKey);
+        }
+
+        internal async Task SendPauseRequest()
+        {
+            NameValueCollection @params = new NameValueCollection { { "pause", "true" } };
+            await QueryAsync("remote/pause.json", true, true, -1, @params).ConfigureAwait(false);
+        }
+
+        internal async Task SendPlayRequest()
+        {
+            NameValueCollection @params = new NameValueCollection { { "pause", "false" } };
+            await QueryAsync("remote/pause.json", true, true, -1, @params).ConfigureAwait(false);
+        }
+
+        internal async Task SendPlayRequest(string url, string context = "")
+        {
+
+            // TODO: instead of having an empty context, one way to fix the bug with the playback time beyond the length of a song would be to provide a 1-song context, and it would be fixed.
+            NameValueCollection @params = new NameValueCollection
+            {
+                {"uri", url},
+                {"context", context}
+            };
+            await QueryAsync($"remote/play.json", true, true, -1, @params).ConfigureAwait(false);
+
+        }
+
+        internal async Task SendQueueRequest(string url)
+        {
+            NameValueCollection @params = new NameValueCollection
+            {
+                {"uri", url},
+                {"action", "queue"}
+            };
+            await QueryAsync("remote/play.json", true, true, -1, @params).ConfigureAwait(false);
+
+        }
+
+        internal StatusResponse GetNewStatus()
+        {
+            string response = Query("remote/status.json", true, true, -1);
+            if (string.IsNullOrEmpty(response))
+                return null;
+            response = response.Replace("\\n", "");
+            List<StatusResponse> raw = JsonConvert.DeserializeObject<List<StatusResponse>>(response);
+            return raw[0];
+        }
+
+        internal string GetOAuthKey()
+        {
+            string raw;
+            using (WebClient wc = GetWebClientWithUserAgentHeader())
+            {
+                raw = wc.DownloadString("http://open.spotify.com/token");
+            }
+            Dictionary<string, object> dic = JsonConvert.DeserializeObject<Dictionary<string, object>>(raw);
+            return dic == null ? "" : (string)dic["t"];
+        }
+
+        internal string GetCfid()
+        {
+            string response = Query("simplecsrf/token.json", false, false, -1);
+            response = response.Replace(@"\", "");
+            List<Cfid> cfidList = (List<Cfid>)JsonConvert.DeserializeObject(response, typeof(List<Cfid>));
+            if (cfidList == null)
+                return "";
+            if (cfidList.Count != 1)
+                throw new Exception("CFID could not be loaded");
+            return cfidList[0].Error == null ? cfidList[0].Token : "";
+        }
+
+        internal string BuildQueryString(bool oauth, bool cfid, int wait, NameValueCollection @params = null)
+        {
+            if (@params == null)
+            {
+                @params = new NameValueCollection();
+            }
+            NameValueCollection queryParameter = HttpUtility.ParseQueryString(string.Empty);
+            queryParameter.Add(@params);
+            queryParameter.Add(new NameValueCollection() {
+                { "ref", string.Empty},
+                { "cors", string.Empty},
+                { "_", GetTimestamp().ToString()}
+            });
+            if (oauth)
+            {
+                queryParameter.Add("oauth", OauthKey);
+            }
+            if (cfid)
+            {
+                queryParameter.Add("csrf", CfidKey);
+            }
+
+            if (wait != -1)
+            {
+                queryParameter.Add("returnafter", wait.ToString());
+                queryParameter.Add("returnon", "login%2Clogout%2Cplay%2Cpause%2Cerror%2Cap");
+            }
+
+            return queryParameter.ToString();
+        }
+        internal string Query(string baseUrl, bool oauth, bool cfid, int wait, NameValueCollection @params = null)
+        {
+            string parameters = BuildQueryString(oauth, cfid, wait, @params);
+            string address = $"{_config.HostUrl}:{_config.Port}/{baseUrl}?{parameters}";
+            string response = string.Empty;
+            try
+            {
+                using (ExtendedWebClient wc = new ExtendedWebClient())
+                {
+                    if (SpotifyLocalAPI.IsSpotifyRunning())
+                    {
+                        response = "[ " + wc.DownloadString(address) + " ]";
+                    }
+                }
+            }
+            catch
+            {
+                return string.Empty;
+            }
+
+            return response;
+        }
+
+        internal async Task<string> QueryAsync(string baseUrl, bool oauth, bool cfid, int wait, NameValueCollection @params = null)
+        {
+            string parameters = BuildQueryString(oauth, cfid, wait, @params);
+            string address = $"{_config.HostUrl}:{_config.Port}/{baseUrl}?{parameters}";
+            string response = "";
+            try
+            {
+                using (ExtendedWebClient wc = new ExtendedWebClient())
+                {
+                    if (SpotifyLocalAPI.IsSpotifyRunning())
+                        response = "[ " + await wc.DownloadStringTaskAsync(new Uri(address)).ConfigureAwait(false) + " ]";
+                }
+            }
+            catch
+            {
+                return string.Empty;
+            }
+
+            return response;
+        }
+        internal int GetTimestamp()
+        {
+            return Convert.ToInt32((DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds);
+        }
+
+        internal WebClient GetWebClientWithUserAgentHeader()
+        {
+            WebClient wc = new WebClient
+            {
+                Proxy = _config?.ProxyConfig?.CreateWebProxy()
+            };
+            wc.Headers.Add(HttpRequestHeader.UserAgent, "Spotify (1.0.50.41368.gbd68dbef)");
+
+            return wc;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/SpotifyLocalAPI.cs
+++ b/SpotifyAPI.Core/Local/SpotifyLocalAPI.cs
@@ -1,0 +1,363 @@
+﻿using SpotifyAPI.Local.Models;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Timers;
+
+namespace SpotifyAPI.Local
+{
+    public class SpotifyLocalAPI : IDisposable
+    {
+        [DllImport("user32.dll")]
+        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
+
+        private bool _listenForEvents;
+
+        public bool ListenForEvents
+        {
+            get
+            {
+                return _listenForEvents;
+            }
+            set
+            {
+                _listenForEvents = value;
+                _eventTimer.Enabled = value;
+            }
+        }
+
+        private ISynchronizeInvoke _synchronizingObject;
+
+        public ISynchronizeInvoke SynchronizingObject
+        {
+            get
+            {
+                return _synchronizingObject;
+            }
+            set
+            {
+                _synchronizingObject = value;
+                _eventTimer.SynchronizingObject = value;
+            }
+        }
+
+        private const int WindowsSevenMajorVersion = 6;
+        private const int WindowsSevenMinorVersion = 1;
+        private const byte VkMediaNextTrack = 0xb0;
+        private const byte VkMediaPrevTrack = 0xb1;
+        private const int KeyeventfExtendedkey = 0x1;
+        private const int KeyeventfKeyup = 0x2;
+
+        private readonly RemoteHandler _rh;
+        private Timer _eventTimer;
+        private StatusResponse _eventStatusResponse;
+
+        public event EventHandler<TrackChangeEventArgs> OnTrackChange;
+
+        public event EventHandler<PlayStateEventArgs> OnPlayStateChange;
+
+        public event EventHandler<VolumeChangeEventArgs> OnVolumeChange;
+
+        public event EventHandler<TrackTimeChangeEventArgs> OnTrackTimeChange;
+
+        public SpotifyLocalAPI(int timerIntervall = 50)
+        {
+            _rh = new RemoteHandler(new SpotifyLocalAPIConfig());
+            AttachTimer(timerIntervall);
+        }
+
+        public SpotifyLocalAPI(SpotifyLocalAPIConfig config)
+        {
+            _rh = new RemoteHandler(config);
+            AttachTimer(config.TimerInterval);
+        }
+
+        private void AttachTimer(int intervall)
+        {
+            _eventTimer = new Timer
+            {
+                Interval = intervall,
+                AutoReset = false,
+                Enabled = false
+            };
+            _eventTimer.Elapsed += ElapsedTick;
+        }
+
+        private void ElapsedTick(object sender, ElapsedEventArgs e)
+        {
+            if (_eventStatusResponse == null)
+            {
+                _eventStatusResponse = GetStatus();
+                _eventTimer.Start();
+                return;
+            }
+            StatusResponse newStatusResponse = GetStatus();
+            if (newStatusResponse == null)
+            {
+                _eventTimer.Start();
+                return;
+            }
+            if (!newStatusResponse.Running && newStatusResponse.Track == null)
+            {
+                _eventTimer.Start();
+                return;
+            }
+            if (newStatusResponse.Track != null && _eventStatusResponse.Track != null)
+            {
+                if (newStatusResponse.Track.TrackResource?.Uri != _eventStatusResponse.Track.TrackResource?.Uri ||
+                    newStatusResponse.Track.IsOtherTrackType() && newStatusResponse.Track.Length != _eventStatusResponse.Track.Length)
+                {
+                    OnTrackChange?.Invoke(this, new TrackChangeEventArgs()
+                    {
+                        OldTrack = _eventStatusResponse.Track,
+                        NewTrack = newStatusResponse.Track
+                    });
+                }
+            }
+            if (newStatusResponse.Playing != _eventStatusResponse.Playing)
+            {
+                OnPlayStateChange?.Invoke(this, new PlayStateEventArgs()
+                {
+                    Playing = newStatusResponse.Playing
+                });
+            }
+            if (newStatusResponse.Volume != _eventStatusResponse.Volume)
+            {
+                OnVolumeChange?.Invoke(this, new VolumeChangeEventArgs()
+                {
+                    OldVolume = _eventStatusResponse.Volume,
+                    NewVolume = newStatusResponse.Volume
+                });
+            }
+            if (newStatusResponse.PlayingPosition != _eventStatusResponse.PlayingPosition)
+            {
+                OnTrackTimeChange?.Invoke(this, new TrackTimeChangeEventArgs()
+                {
+                    TrackTime = newStatusResponse.PlayingPosition
+                });
+            }
+            _eventStatusResponse = newStatusResponse;
+            _eventTimer.Start();
+        }
+
+        private bool IsOSCompatible(int minMajor, int minMinor)
+        {
+            return Environment.OSVersion.Version.Major > minMajor || (Environment.OSVersion.Version.Major == minMajor && Environment.OSVersion.Version.Minor >= minMinor);
+        }
+        /// <summary>
+        /// Connects with Spotify. Needs to be called before all other SpotifyAPI functions
+        /// </summary>
+        /// <returns>Returns true, if it was successful, false if not</returns>
+        public Boolean Connect()
+        {
+            return _rh.Init();
+        }
+
+        /// <summary>
+        /// Update and returns the new StatusResponse from the Spotify-Player
+        /// </summary>
+        /// <returns>An up-to-date StatusResponse</returns>
+        public StatusResponse GetStatus()
+        {
+            return _rh.GetNewStatus();
+        }
+
+        /// <summary>
+        /// Mutes Spotify (Requires Windows 7 or newer)
+        /// </summary>
+        public void Mute()
+        {
+            if(!IsOSCompatible(WindowsSevenMajorVersion, WindowsSevenMinorVersion))
+                throw new NotSupportedException("This feature is only available on Windows 7 or newer");
+            VolumeMixerControl.MuteSpotify(true);
+        }
+
+        /// <summary>
+        /// Unmutes Spotify (Requires Windows 7 or newer)
+        /// </summary>
+        public void UnMute()
+        {
+            if (!IsOSCompatible(WindowsSevenMajorVersion, WindowsSevenMinorVersion))
+                throw new NotSupportedException("This feature is only available on Windows 7 or newer");
+            VolumeMixerControl.MuteSpotify(false);
+        }
+
+        /// <summary>
+        /// Checks whether Spotify is muted in the Volume Mixer control (required Windows 7 or newer)
+        /// </summary>
+        /// <returns>Null if an error occured, otherwise the muted state</returns>
+        public bool IsSpotifyMuted()
+        {
+            if (!IsOSCompatible(WindowsSevenMajorVersion, WindowsSevenMinorVersion))
+                throw new NotSupportedException("This feature is only available on Windows 7 or newer");
+            return VolumeMixerControl.IsSpotifyMuted();
+        }
+
+        /// <summary>
+        ///  Sets the Volume Mixer volume (requires Windows 7 or newer)
+        /// </summary>
+        /// <param name="volume">A value between 0 and 100</param>
+        public void SetSpotifyVolume(float volume = 100)
+        {
+            if (!IsOSCompatible(WindowsSevenMajorVersion, WindowsSevenMinorVersion))
+                throw new NotSupportedException("This feature is only available on Windows 7 or newer");
+            if (volume < 0 || volume > 100)
+                throw new ArgumentOutOfRangeException(nameof(volume));
+            VolumeMixerControl.SetSpotifyVolume(volume);
+        }
+
+        /// <summary>
+        /// Return the Volume Mixer volume of Spotify (requires Windows 7 or newer)
+        /// </summary>
+        /// <returns>Null if an error occured, otherwise a float between 0 and 100</returns>
+        public float GetSpotifyVolume()
+        {
+            if (!IsOSCompatible(WindowsSevenMajorVersion, WindowsSevenMinorVersion))
+                throw new NotSupportedException("This feature is only available on Windows 7 or newer");
+            return VolumeMixerControl.GetSpotifyVolume();
+        }
+
+        /// <summary>
+        /// Pause function
+        /// </summary>
+        public async Task Pause()
+        {
+            await _rh.SendPauseRequest();
+        }
+
+        /// <summary>
+        /// Play function
+        /// </summary>
+        public async Task Play()
+        {
+            await _rh.SendPlayRequest();
+        }
+
+        /// <summary>
+        /// Simulates a KeyPress
+        /// </summary>
+        /// <param name="keyCode">The keycode for the represented Key</param>
+        internal void PressKey(byte keyCode)
+        {
+            keybd_event(keyCode, 0x45, KeyeventfExtendedkey, 0);
+            keybd_event(keyCode, 0x45, KeyeventfExtendedkey | KeyeventfKeyup, 0);
+        }
+
+        /// <summary>
+        /// Plays a Spotify URI within an optional context.
+        /// </summary>
+        /// <param name="uri">The Spotify URI</param>
+        /// <param name="context">The context in which to play the specified <paramref name="uri"/>. </param>
+        /// <remarks>
+        /// Contexts are basically a queue in spotify. a song can be played within a context, meaning that hitting next / previous would lead to another song. Contexts are leveraged by widgets as described in the "Multiple tracks player" section of the following documentation page: https://developer.spotify.com/technologies/widgets/spotify-play-button/
+        /// </remarks>
+        public async Task PlayURL(string uri, string context = "")
+        {
+            await _rh.SendPlayRequest(uri, context);
+        }
+
+        /// <summary>
+        /// Adds a Spotify URI to the Queue
+        /// </summary>
+        /// <param name="uri">The Spotify URI</param>
+        [Obsolete("This method doesn't work with the current spotify version.")]
+        public async Task AddToQueue(string uri)
+        {
+            await _rh.SendQueueRequest(uri);
+        }
+
+        /// <summary>
+        /// Skips the current song (Using keypress simulation)
+        /// </summary>
+        public void Skip()
+        {
+            PressKey(VkMediaNextTrack);
+        }
+
+        /// <summary>
+        /// Emulates the "Previous" Key (Using keypress simulation)
+        /// </summary>
+        public void Previous()
+        {
+            PressKey(VkMediaPrevTrack);
+        }
+
+        /// <summary>
+        /// Checks if Spotify is running
+        /// </summary>
+        /// <returns>True, if it's running, false if not</returns>
+        public static Boolean IsSpotifyRunning()
+        {
+            return Process.GetProcessesByName("spotify").Length >= 1;
+        }
+
+        /// <summary>
+        /// Checks if Spotify's WebHelper is running (Needed for API Calls)
+        /// </summary>
+        /// <returns>True, if it's running, false if not</returns>
+        public static Boolean IsSpotifyWebHelperRunning()
+        {
+            return Process.GetProcessesByName("spotifywebhelper").Length >= 1;
+        }
+
+        /// <summary>
+        /// Determines whether [spotify is installed].
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if [spotify is installed]; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsSpotifyInstalled()
+        {
+            bool isInstalled = false;
+
+            // Checks if UWP Spotify is installed.
+            string uwpSpotifyPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Packages\SpotifyAB.SpotifyMusic_zpdnekdrzrea0");
+
+            isInstalled = Directory.Exists(uwpSpotifyPath);
+
+            // If UWP Spotify is not installed, try look for desktop version
+            if (!isInstalled)
+            {
+                string desktopSpotifyPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"Spotify\Spotify.exe");
+                isInstalled = File.Exists(desktopSpotifyPath);
+            }
+
+            return isInstalled;
+        }
+
+        /// <summary>
+        /// Runs Spotify
+        /// </summary>
+        public static void RunSpotify()
+        {
+            if (!IsSpotifyRunning() && File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\spotify.exe")))
+                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\spotify.exe"));
+        }
+
+        /// <summary>
+        /// Runs Spotify's WebHelper
+        /// </summary>
+        public static void RunSpotifyWebHelper()
+        {
+            if (!IsSpotifyWebHelperRunning() && File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\data\spotifywebhelper.exe")))
+            {
+                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\data\spotifywebhelper.exe"));
+            }
+            else if (!IsSpotifyWebHelperRunning() && File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\spotifywebhelper.exe")))
+            {
+                Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"spotify\spotifywebhelper.exe"));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_eventTimer == null)
+                return;
+            _eventTimer.Enabled = false;
+            _eventTimer.Elapsed -= ElapsedTick;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Local/SpotifyLocalAPIConfig.cs
+++ b/SpotifyAPI.Core/Local/SpotifyLocalAPIConfig.cs
@@ -1,0 +1,14 @@
+﻿namespace SpotifyAPI.Local
+{
+    // ReSharper disable once InconsistentNaming
+    public class SpotifyLocalAPIConfig
+    {
+        public int TimerInterval { get; set; } = 50;
+
+        public string HostUrl { get; set; } = "http://127.0.0.1";
+
+        public int Port { get; set; } = 4381;
+
+        public ProxyConfig ProxyConfig { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Local/VolumeMixerControl.cs
+++ b/SpotifyAPI.Core/Local/VolumeMixerControl.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace SpotifyAPI.Local
+{
+    internal static class VolumeMixerControl
+    {
+        private const string SpotifyProcessName = "spotify";
+
+        internal static float GetSpotifyVolume()
+        {
+            ISimpleAudioVolume volume = GetSpotifyVolumeObject();
+
+            if (volume == null)
+            {
+                throw new COMException("Volume object creation failed");
+            }
+
+            volume.GetMasterVolume(out float level);
+            Marshal.ReleaseComObject(volume);
+            return level * 100;
+        }
+
+        internal static bool IsSpotifyMuted()
+        {
+            ISimpleAudioVolume volume = GetSpotifyVolumeObject();
+
+            if (volume == null)
+            {
+                throw new COMException("Volume object creation failed");
+            }
+
+            volume.GetMute(out bool mute);
+            Marshal.ReleaseComObject(volume);
+            return mute;
+        }
+
+        internal static void SetSpotifyVolume(float level)
+        {
+            ISimpleAudioVolume volume = GetSpotifyVolumeObject();
+
+            if (volume == null)
+            {
+                throw new COMException("Volume object creation failed");
+            }
+
+            Guid guid = Guid.Empty;
+            volume.SetMasterVolume(level / 100, ref guid);
+            Marshal.ReleaseComObject(volume);
+        }
+
+        internal static void MuteSpotify(bool mute)
+        {
+            ISimpleAudioVolume volume = GetSpotifyVolumeObject();
+
+            if (volume == null)
+            {
+                throw new COMException("Volume object creation failed");
+            }
+
+            Guid guid = Guid.Empty;
+            volume.SetMute(mute, ref guid);
+            Marshal.ReleaseComObject(volume);
+        }
+
+        private static ISimpleAudioVolume GetSpotifyVolumeObject()
+        {
+            var audioVolumeObjects = from p in Process.GetProcessesByName(SpotifyProcessName)
+                                     let vol = GetVolumeObject(p.Id)
+                                     where vol != null
+                                     select vol;
+            return audioVolumeObjects.FirstOrDefault();
+        }
+
+        private static ISimpleAudioVolume GetVolumeObject(int pid)
+        {
+            // get the speakers (1st render + multimedia) device
+            IMmDeviceEnumerator deviceEnumerator = (IMmDeviceEnumerator) new MMDeviceEnumerator();
+            deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.ERender, ERole.EMultimedia, out IMmDevice speakers);
+
+            speakers.GetId(out string defaultDeviceId);
+
+            ISimpleAudioVolume volumeControl = GetVolumeObject(pid, speakers);
+            Marshal.ReleaseComObject(speakers);
+
+            if (volumeControl == null)
+            {
+                // If volumeControl is null, then the process's volume object might be on a different device.
+                // This happens if the process doesn't use the default device.
+                // 
+                // As far as Spotify is concerned, if using the "--enable-audio-graph" command line argument,
+                // a new option becomes available in the Settings that makes it possible to change the playback device.
+
+                deviceEnumerator.EnumAudioEndpoints(EDataFlow.ERender, EDeviceState.Active, out IMmDeviceCollection deviceCollection);
+
+                deviceCollection.GetCount(out int count);
+                for (int i = 0; i < count; i++)
+                {
+                    deviceCollection.Item(i, out IMmDevice device);
+                    device.GetId(out string deviceId);
+
+                    try
+                    {
+                        if (deviceId == defaultDeviceId)
+                            continue;
+
+                        volumeControl = GetVolumeObject(pid, device);
+                        if (volumeControl != null)
+                            break;
+                    }
+                    finally
+                    {
+                        Marshal.ReleaseComObject(device);
+                    }
+                }
+            }
+            
+            Marshal.ReleaseComObject(deviceEnumerator);
+            return volumeControl;
+        }
+
+        private static ISimpleAudioVolume GetVolumeObject(int pid, IMmDevice device)
+        {
+            // activate the session manager. we need the enumerator
+            Guid iidIAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;
+            device.Activate(ref iidIAudioSessionManager2, 0, IntPtr.Zero, out object o);
+            IAudioSessionManager2 mgr = (IAudioSessionManager2) o;
+
+            // enumerate sessions for on this device
+            mgr.GetSessionEnumerator(out IAudioSessionEnumerator sessionEnumerator);
+            sessionEnumerator.GetCount(out int count);
+
+            // search for an audio session with the required name
+            // NOTE: we could also use the process id instead of the app name (with IAudioSessionControl2)
+            ISimpleAudioVolume volumeControl = null;
+            for (int i = 0; i < count; i++)
+            {
+                sessionEnumerator.GetSession(i, out IAudioSessionControl2 ctl);
+                ctl.GetProcessId(out int cpid);
+
+                if (cpid == pid)
+                {
+                    volumeControl = (ISimpleAudioVolume) ctl;
+                    break;
+                }
+                Marshal.ReleaseComObject(ctl);
+            }
+            Marshal.ReleaseComObject(sessionEnumerator);
+            Marshal.ReleaseComObject(mgr);
+            return volumeControl;
+        }
+
+        [ComImport]
+        [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+        private class MMDeviceEnumerator
+        {
+        }
+
+        private enum EDataFlow
+        {
+            ERender,
+            ECapture,
+            EAll,
+            EDataFlowEnumCount
+        }
+
+        private enum ERole
+        {
+            EConsole,
+            EMultimedia,
+            ECommunications,
+            ERoleEnumCount
+        }
+
+        [Flags]
+        private enum EDeviceState
+        {
+            Active = 0x00000001,
+            Disabled = 0x00000002,
+            NotPresent = 0x00000004,
+            UnPlugged = 0x00000008,
+            All = 0x0000000F
+        }
+
+        [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMmDeviceEnumerator
+        {
+            [PreserveSig]
+            int EnumAudioEndpoints(EDataFlow dataFlow, EDeviceState stateMask, [Out] out IMmDeviceCollection deviceCollection);
+
+            [PreserveSig]
+            int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, out IMmDevice ppDevice);
+        }
+
+        [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMmDevice
+        {
+            [PreserveSig]
+            int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
+
+            int OpenPropertyStore_NotImpl();
+
+            [PreserveSig]
+            int GetId([Out, MarshalAs(UnmanagedType.LPWStr)] out string ppstrId);
+        }
+
+        [Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMmDeviceCollection
+        {
+            [PreserveSig]
+            int GetCount(out int deviceCount);
+
+            [PreserveSig]
+            int Item(int deviceIndex, [Out] out IMmDevice device);
+        }
+
+        [Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAudioSessionManager2
+        {
+            int NotImpl1();
+
+            int NotImpl2();
+
+            [PreserveSig]
+            int GetSessionEnumerator(out IAudioSessionEnumerator sessionEnum);
+        }
+
+        [Guid("E2F5BB11-0570-40CA-ACDD-3AA01277DEE8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAudioSessionEnumerator
+        {
+            [PreserveSig]
+            int GetCount(out int sessionCount);
+
+            [PreserveSig]
+            int GetSession(int sessionCount, out IAudioSessionControl2 session);
+        }
+
+        [Guid("87CE5498-68D6-44E5-9215-6DA47EF883D8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface ISimpleAudioVolume
+        {
+            [PreserveSig]
+            int SetMasterVolume(float fLevel, ref Guid eventContext);
+
+            [PreserveSig]
+            int GetMasterVolume(out float pfLevel);
+
+            [PreserveSig]
+            int SetMute(bool bMute, ref Guid eventContext);
+
+            [PreserveSig]
+            int GetMute(out bool pbMute);
+        }
+
+        [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAudioSessionControl2
+        {
+            [PreserveSig]
+            int NotImpl0();
+
+            [PreserveSig]
+            int GetDisplayName([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+            [PreserveSig]
+            int SetDisplayName([MarshalAs(UnmanagedType.LPWStr)]string value, [MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+            [PreserveSig]
+            int GetIconPath([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+            [PreserveSig]
+            int SetIconPath([MarshalAs(UnmanagedType.LPWStr)] string value, [MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+            [PreserveSig]
+            int GetGroupingParam(out Guid pRetVal);
+
+            [PreserveSig]
+            int SetGroupingParam([MarshalAs(UnmanagedType.LPStruct)] Guid Override, [MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+            [PreserveSig]
+            int NotImpl1();
+
+            [PreserveSig]
+            int NotImpl2();
+
+            [PreserveSig]
+            int GetSessionIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+            [PreserveSig]
+            int GetSessionInstanceIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+            [PreserveSig]
+            int GetProcessId(out int pRetVal);
+
+            [PreserveSig]
+            int IsSystemSoundsSession();
+
+            [PreserveSig]
+            int SetDuckingPreference(bool optOut);
+        }
+    }
+}

--- a/SpotifyAPI.Core/ProxyConfig.cs
+++ b/SpotifyAPI.Core/ProxyConfig.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Net;
+
+namespace SpotifyAPI
+{
+    public class ProxyConfig
+    {
+        public string Host { get; set; }
+
+        public int Port { get; set; } = 80;
+
+        public string Username { get; set; }
+
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Whether to bypass the proxy server for local addresses.
+        /// </summary>
+        public bool BypassProxyOnLocal { get; set; }
+
+        public void Set(ProxyConfig proxyConfig)
+        {
+            Host = proxyConfig?.Host;
+            Port = proxyConfig?.Port ?? 80;
+            Username = proxyConfig?.Username;
+            Password = proxyConfig?.Password;
+            BypassProxyOnLocal = proxyConfig?.BypassProxyOnLocal ?? false;
+        }
+
+        /// <summary>
+        /// Whether both <see cref="Host"/> and <see cref="Port"/> have valid values.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsValid()
+        {
+            return !string.IsNullOrWhiteSpace(Host) && Port > 0;
+        }
+
+        /// <summary>
+        /// Create a <see cref="Uri"/> from the host and port number
+        /// </summary>
+        /// <returns>A URI</returns>
+        public Uri GetUri()
+        {
+            UriBuilder uriBuilder = new UriBuilder(Host)
+            {
+                Port = Port
+            };
+            return uriBuilder.Uri;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="WebProxy"/> from the proxy details of this object.
+        /// </summary>
+        /// <returns>A <see cref="WebProxy"/> or <code>null</code> if the proxy details are invalid.</returns>
+        public WebProxy CreateWebProxy()
+        {
+            if (!IsValid())
+                return null;
+
+            WebProxy proxy = new WebProxy
+            {
+                Address = GetUri(),
+                UseDefaultCredentials = true,
+                BypassProxyOnLocal = BypassProxyOnLocal
+            };
+
+            if (!string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password))
+            {
+                proxy.UseDefaultCredentials = false;
+                proxy.Credentials = new NetworkCredential(Username, Password);
+            }
+
+            return proxy;
+        }
+    }
+}

--- a/SpotifyAPI.Core/SpotifyAPI.Core.csproj
+++ b/SpotifyAPI.Core/SpotifyAPI.Core.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview2-26406-04" />
+  </ItemGroup>
+
+</Project>

--- a/SpotifyAPI.Core/Web/Auth/AutorizationCodeAuth.cs
+++ b/SpotifyAPI.Core/Web/Auth/AutorizationCodeAuth.cs
@@ -1,0 +1,169 @@
+﻿using Newtonsoft.Json;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+using System;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+
+namespace SpotifyAPI.Web.Auth
+{
+    public class AutorizationCodeAuth
+    {
+        public delegate void OnResponseReceived(AutorizationCodeAuthResponse response);
+
+        private SimpleHttpServer _httpServer;
+        private Thread _httpThread;
+        public string ClientId { get; set; }
+        public string RedirectUri { get; set; }
+        public string State { get; set; }
+        public Scope Scope { get; set; }
+        public Boolean ShowDialog { get; set; }
+        public Action<string> OpenUriAction { get; set; }
+
+        /// <summary>
+        ///     Will be fired once the user authenticated
+        /// </summary>
+        public event OnResponseReceived OnResponseReceivedEvent;
+
+        /// <summary>
+        ///     Start the auth process (Make sure the internal HTTP-Server ist started)
+        /// </summary>
+        public void DoAuth()
+        {
+            string uri = GetUri();
+
+            if (OpenUriAction == null)
+            {
+                Process.Start(uri);
+            }
+            else
+            {
+                OpenUriAction(uri);
+            }
+        }
+
+        /// <summary>
+        ///     Refreshes auth by providing the clientsecret (Don't use this if you're on a client)
+        /// </summary>
+        /// <param name="refreshToken">The refresh-token of the earlier gathered token</param>
+        /// <param name="clientSecret">Your Client-Secret, don't provide it if this is running on a client!</param>
+        public Token RefreshToken(string refreshToken, string clientSecret)
+        {
+            using (WebClient wc = new WebClient())
+            {
+                wc.Headers.Add("Authorization",
+                    "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(ClientId + ":" + clientSecret)));
+                NameValueCollection col = new NameValueCollection
+                {
+                    {"grant_type", "refresh_token"},
+                    {"refresh_token", refreshToken}
+                };
+
+                string response;
+                try
+                {
+                    byte[] data = wc.UploadValues("https://accounts.spotify.com/api/token", "POST", col);
+                    response = Encoding.UTF8.GetString(data);
+                }
+                catch (WebException e)
+                {
+                    using (StreamReader reader = new StreamReader(e.Response.GetResponseStream()))
+                    {
+                        response = reader.ReadToEnd();
+                    }
+                }
+                return JsonConvert.DeserializeObject<Token>(response);
+            }
+        }
+
+        private string GetUri()
+        {
+            StringBuilder builder = new StringBuilder("https://accounts.spotify.com/authorize/?");
+            builder.Append("client_id=" + ClientId);
+            builder.Append("&response_type=code");
+            builder.Append("&redirect_uri=" + RedirectUri);
+            builder.Append("&state=" + State);
+            builder.Append("&scope=" + Scope.GetStringAttribute(" "));
+            builder.Append("&show_dialog=" + ShowDialog);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Start the internal HTTP-Server
+        /// </summary>
+        public void StartHttpServer(int port = 80)
+        {
+            _httpServer = new SimpleHttpServer(port, AuthType.Authorization);
+            _httpServer.OnAuth += HttpServerOnOnAuth;
+
+            _httpThread = new Thread(_httpServer.Listen);
+            _httpThread.Start();
+        }
+
+        private void HttpServerOnOnAuth(AuthEventArgs e)
+        {
+            OnResponseReceivedEvent?.Invoke(new AutorizationCodeAuthResponse()
+            {
+                Code = e.Code,
+                State = e.State,
+                Error = e.Error
+            });
+        }
+
+        /// <summary>
+        ///     This will stop the internal HTTP-Server (Should be called after you got the Token)
+        /// </summary>
+        public void StopHttpServer()
+        {
+            _httpServer.Dispose();
+            _httpServer = null;
+        }
+
+        /// <summary>
+        ///     Exchange a code for a Token (Don't use this if you're on a client)
+        /// </summary>
+        /// <param name="code">The gathered code from the response</param>
+        /// <param name="clientSecret">Your Client-Secret, don't provide it if this is running on a client!</param>
+        /// <returns></returns>
+        public Token ExchangeAuthCode(string code, string clientSecret)
+        {
+            using (WebClient wc = new WebClient())
+            {
+                NameValueCollection col = new NameValueCollection
+                {
+                    {"grant_type", "authorization_code"},
+                    {"code", code},
+                    {"redirect_uri", RedirectUri},
+                    {"client_id", ClientId},
+                    {"client_secret", clientSecret}
+                };
+
+                string response;
+                try
+                {
+                    byte[] data = wc.UploadValues("https://accounts.spotify.com/api/token", "POST", col);
+                    response = Encoding.UTF8.GetString(data);
+                }
+                catch (WebException e)
+                {
+                    using (StreamReader reader = new StreamReader(e.Response.GetResponseStream()))
+                    {
+                        response = reader.ReadToEnd();
+                    }
+                }
+                return JsonConvert.DeserializeObject<Token>(response);
+            }
+        }
+    }
+
+    public struct AutorizationCodeAuthResponse
+    {
+        public string Code { get; set; }
+        public string State { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Auth/ClientCredentialsAuth.cs
+++ b/SpotifyAPI.Core/Web/Auth/ClientCredentialsAuth.cs
@@ -1,0 +1,85 @@
+﻿using Newtonsoft.Json;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpotifyAPI.Web.Auth
+{
+    public class ClientCredentialsAuth
+    {
+        public Scope Scope { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        ///     Starts the auth process and
+        /// </summary>
+        /// <returns>A new Token</returns>
+        public Token DoAuth()
+        {
+            using (WebClient wc = new WebClient())
+            {
+                wc.Headers.Add("Authorization",
+                    "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(ClientId + ":" + ClientSecret)));
+
+                NameValueCollection col = new NameValueCollection
+                {
+                    {"grant_type", "client_credentials"},
+                    {"scope", Scope.GetStringAttribute(" ")}
+                };
+
+                byte[] data;
+                try
+                {
+                    data = wc.UploadValues("https://accounts.spotify.com/api/token", "POST", col);
+                }
+                catch (WebException e)
+                {
+                    using (StreamReader reader = new StreamReader(e.Response.GetResponseStream()))
+                    {
+                        data = Encoding.UTF8.GetBytes(reader.ReadToEnd());
+                    }
+                }
+                return JsonConvert.DeserializeObject<Token>(Encoding.UTF8.GetString(data));
+            }
+        }
+
+        /// <summary>
+        ///     Starts the auth process async and
+        /// </summary>
+        /// <returns>A new Token</returns>
+        public async Task<Token> DoAuthAsync()
+        {
+            using (WebClient wc = new WebClient())
+            {
+                wc.Headers.Add("Authorization",
+                    "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(ClientId + ":" + ClientSecret)));
+
+                NameValueCollection col = new NameValueCollection
+                {
+                    {"grant_type", "client_credentials"},
+                    {"scope", Scope.GetStringAttribute(" ")}
+                };
+
+                byte[] data;
+                try
+                {
+                    data = await wc.UploadValuesTaskAsync("https://accounts.spotify.com/api/token", "POST", col);
+                }
+                catch (WebException e)
+                {
+                    using (StreamReader reader = new StreamReader(e.Response.GetResponseStream()))
+                    {
+                        data = Encoding.UTF8.GetBytes(await reader.ReadToEndAsync());
+                    }
+                }
+                return JsonConvert.DeserializeObject<Token>(Encoding.UTF8.GetString(data));
+            }
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/Auth/ImplicitGrantAuth.cs
+++ b/SpotifyAPI.Core/Web/Auth/ImplicitGrantAuth.cs
@@ -1,0 +1,77 @@
+﻿using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace SpotifyAPI.Web.Auth
+{
+    public class ImplicitGrantAuth
+    {
+        public delegate void OnResponseReceived(Token token, string state);
+
+        private SimpleHttpServer _httpServer;
+        private Thread _httpThread;
+        public string ClientId { get; set; }
+        public string RedirectUri { get; set; }
+        public string State { get; set; }
+        public Scope Scope { get; set; }
+        public Boolean ShowDialog { get; set; }
+
+        public event OnResponseReceived OnResponseReceivedEvent;
+
+        /// <summary>
+        ///     Start the auth process (Make sure the internal HTTP-Server ist started)
+        /// </summary>
+        public void DoAuth()
+        {
+            string uri = GetUri();
+            Process.Start(uri);
+        }
+
+        private string GetUri()
+        {
+            StringBuilder builder = new StringBuilder("https://accounts.spotify.com/authorize/?");
+            builder.Append("client_id=" + ClientId);
+            builder.Append("&response_type=token");
+            builder.Append("&redirect_uri=" + RedirectUri);
+            builder.Append("&state=" + State);
+            builder.Append("&scope=" + Scope.GetStringAttribute(" "));
+            builder.Append("&show_dialog=" + ShowDialog);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Start the internal HTTP-Server
+        /// </summary>
+        public void StartHttpServer(int port = 80)
+        {
+            _httpServer = new SimpleHttpServer(port, AuthType.Implicit);
+            _httpServer.OnAuth += HttpServerOnOnAuth;
+
+            _httpThread = new Thread(_httpServer.Listen);
+            _httpThread.Start();
+        }
+
+        private void HttpServerOnOnAuth(AuthEventArgs e)
+        {
+            OnResponseReceivedEvent?.Invoke(new Token
+            {
+                AccessToken = e.Code,
+                TokenType = e.TokenType,
+                ExpiresIn = e.ExpiresIn,
+                Error = e.Error
+            }, e.State);
+        }
+
+        /// <summary>
+        ///     This will stop the internal HTTP-Server (Should be called after you got the Token)
+        /// </summary>
+        public void StopHttpServer()
+        {
+            _httpServer.Dispose();
+            _httpServer = null;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/Auth/WebApiFactory.cs
+++ b/SpotifyAPI.Core/Web/Auth/WebApiFactory.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+
+namespace SpotifyAPI.Web.Auth
+{
+    public class WebAPIFactory
+    {
+        private readonly string _redirectUrl;
+        private readonly int _listeningPort;
+        private readonly string _clientId;
+        private readonly TimeSpan _timeout;
+        private readonly Scope _scope;
+        private readonly ProxyConfig _proxyConfig;
+        private readonly string _xss;
+
+        public WebAPIFactory(string redirectUrl, int listeningPort, string clientId, Scope scope)
+            : this(redirectUrl, listeningPort, clientId, scope, null)
+        {
+        }
+
+        public WebAPIFactory(string redirectUrl, int listeningPort, string clientId, Scope scope, ProxyConfig proxyConfig)
+            : this(redirectUrl, listeningPort, clientId, scope, TimeSpan.FromSeconds(20), proxyConfig)
+        {
+        }
+
+        public WebAPIFactory(string redirectUrl, int listeningPort, string clientId, Scope scope, TimeSpan timeout, string xss = "XSS")
+            : this(redirectUrl, listeningPort, clientId, scope, timeout, null, xss)
+        {
+        }
+
+        public WebAPIFactory(string redirectUrl, int listeningPort, string clientId, Scope scope, TimeSpan timeout, ProxyConfig proxyConfig, string xss = "XSS")
+        {
+            _redirectUrl = redirectUrl;
+            _listeningPort = listeningPort;
+            _clientId = clientId;
+            _scope = scope;
+            _timeout = timeout;
+            _proxyConfig = proxyConfig;
+            _xss = xss;
+        }
+
+        public Task<SpotifyWebAPI> GetWebApi()
+        {
+            var authentication = new ImplicitGrantAuth
+            {
+                RedirectUri = new UriBuilder(_redirectUrl) { Port = _listeningPort }.Uri.OriginalString.TrimEnd('/'),
+                ClientId = _clientId,
+                Scope = _scope,
+                State = _xss
+            };
+
+            AutoResetEvent authenticationWaitFlag = new AutoResetEvent(false);
+            SpotifyWebAPI spotifyWebApi = null;
+            authentication.OnResponseReceivedEvent += (token, state) =>
+            {
+                spotifyWebApi = HandleSpotifyResponse(state, token);
+                authenticationWaitFlag.Set();
+            };
+
+            try
+            {
+                authentication.StartHttpServer(_listeningPort);
+
+                authentication.DoAuth();
+
+                authenticationWaitFlag.WaitOne(_timeout);
+                if (spotifyWebApi == null)
+                    throw new TimeoutException($"No valid response received for the last {_timeout.TotalSeconds} seconds");
+            }
+            finally
+            {
+                authentication.StopHttpServer();
+            }
+
+            return Task.FromResult(spotifyWebApi);
+        }
+
+        private SpotifyWebAPI HandleSpotifyResponse(string state, Token token)
+        {
+            if (state != _xss)
+                throw new SpotifyWebApiException($"Wrong state '{state}' received.");
+
+            if (token.Error != null)
+                throw new SpotifyWebApiException($"Error: {token.Error}");
+            
+            var spotifyWebApi = new SpotifyWebAPI(_proxyConfig)
+            {
+                UseAuth = true,
+                AccessToken = token.AccessToken,
+                TokenType = token.TokenType
+            };
+
+            return spotifyWebApi;
+        }
+    }
+
+    [Serializable]
+    public class SpotifyWebApiException : Exception
+    {
+        public SpotifyWebApiException(string message) : base(message)
+        { }
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/AlbumType.cs
+++ b/SpotifyAPI.Core/Web/Enums/AlbumType.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    [Flags]
+    public enum AlbumType
+    {
+        [String("album")]
+        Album = 1,
+
+        [String("single")]
+        Single = 2,
+
+        [String("compilation")]
+        Compilation = 4,
+
+        [String("appears_on")]
+        AppearsOn = 8,
+
+        [String("album,single,compilation,appears_on")]
+        All = 16
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/FollowType.cs
+++ b/SpotifyAPI.Core/Web/Enums/FollowType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    [Flags]
+    public enum FollowType
+    {
+        [String("artist")]
+        Artist = 1,
+
+        [String("user")]
+        User = 2
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/RepeatState.cs
+++ b/SpotifyAPI.Core/Web/Enums/RepeatState.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    [Flags]
+    public enum RepeatState
+    {
+        [String("track")]
+        Track = 1,
+
+        [String("context")]
+        Context = 2,
+
+        [String("off")]
+        Off = 4
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/Scope.cs
+++ b/SpotifyAPI.Core/Web/Enums/Scope.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    [Flags]
+    public enum Scope
+    {
+        [String("")]
+        None = 1,
+
+        [String("playlist-modify-public")]
+        PlaylistModifyPublic = 2,
+
+        [String("playlist-modify-private")]
+        PlaylistModifyPrivate = 4,
+
+        [String("playlist-read-private")]
+        PlaylistReadPrivate = 8,
+
+        [String("streaming")]
+        Streaming = 16,
+
+        [String("user-read-private")]
+        UserReadPrivate = 32,
+
+        [String("user-read-email")]
+        UserReadEmail = 64,
+
+        [String("user-library-read")]
+        UserLibraryRead = 128,
+
+        [String("user-library-modify")]
+        UserLibraryModify = 256,
+
+        [String("user-follow-modify")]
+        UserFollowModify = 512,
+
+        [String("user-follow-read")]
+        UserFollowRead = 1024,
+
+        [String("user-read-birthdate")]
+        UserReadBirthdate = 2048,
+
+        [String("user-top-read")]
+        UserTopRead = 4096,
+
+        [String("playlist-read-collaborative")]
+        PlaylistReadCollaborative = 8192,
+
+        [String("user-read-recently-played")]
+        UserReadRecentlyPlayed = 16384,
+
+        [String("user-read-playback-state")]
+        UserReadPlaybackState = 32768,
+
+        [String("user-modify-playback-state")]
+        UserModifyPlaybackState = 65536
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/SearchType.cs
+++ b/SpotifyAPI.Core/Web/Enums/SearchType.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    [Flags]
+    public enum SearchType
+    {
+        [String("artist")]
+        Artist = 1,
+
+        [String("album")]
+        Album = 2,
+
+        [String("track")]
+        Track = 4,
+
+        [String("playlist")]
+        Playlist = 8,
+
+        [String("track,album,artist,playlist")]
+        All = 16
+    }
+}

--- a/SpotifyAPI.Core/Web/Enums/TimeRangeType.cs
+++ b/SpotifyAPI.Core/Web/Enums/TimeRangeType.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SpotifyAPI.Web.Enums
+{
+    /// <summary>
+    ///     Only one value allowed
+    /// </summary>
+    [Flags]
+    public enum TimeRangeType
+    {
+        [String("long_term")]
+        LongTerm = 1,
+
+        [String("medium_term")]
+        MediumTerm = 2,
+
+        [String("short_term")]
+        ShortTerm = 4
+    }
+}

--- a/SpotifyAPI.Core/Web/IClient.cs
+++ b/SpotifyAPI.Core/Web/IClient.cs
@@ -1,0 +1,126 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using SpotifyAPI.Web.Models;
+
+namespace SpotifyAPI.Web
+{
+    public interface IClient : IDisposable
+    {
+        JsonSerializerSettings JsonSettings { get; set; }
+
+        /// <summary>
+        ///     Downloads data from an URL and returns it
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, string> Download(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Downloads data async from an URL and returns it
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, string>> DownloadAsync(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Downloads data from an URL and returns it
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, byte[]> DownloadRaw(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Downloads data async from an URL and returns it
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, byte[]>> DownloadRawAsync(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Downloads data from an URL and converts it to an object
+        /// </summary>
+        /// <typeparam name="T">The Type which the object gets converted to</typeparam>
+        /// <param name="url">An URL</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, T> DownloadJson<T>(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Downloads data async from an URL and converts it to an object
+        /// </summary>
+        /// <typeparam name="T">The Type which the object gets converted to</typeparam>
+        /// <param name="url">An URL</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, T>> DownloadJsonAsync<T>(string url, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data from an URL and returns the response
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, string> Upload(string url, string body, string method, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data async from an URL and returns the response
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, string>> UploadAsync(string url, string body, string method, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data from an URL and returns the response
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, byte[]> UploadRaw(string url, string body, string method, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data async from an URL and returns the response
+        /// </summary>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, byte[]>> UploadRawAsync(string url, string body, string method, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data from an URL and converts the response to an object
+        /// </summary>
+        /// <typeparam name="T">The Type which the object gets converted to</typeparam>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Tuple<ResponseInfo, T> UploadJson<T>(string url, string body, string method, Dictionary<string, string> headers = null);
+
+        /// <summary>
+        ///     Uploads data async from an URL and converts the response to an object
+        /// </summary>
+        /// <typeparam name="T">The Type which the object gets converted to</typeparam>
+        /// <param name="url">An URL</param>
+        /// <param name="body">The Body-Data (most likely a JSON String)</param>
+        /// <param name="method">The Upload-method (POST,DELETE,PUT)</param>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        Task<Tuple<ResponseInfo, T>> UploadJsonAsync<T>(string url, string body, string method, Dictionary<string, string> headers = null);
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AnalysisMeta.cs
+++ b/SpotifyAPI.Core/Web/Models/AnalysisMeta.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisMeta
+    {
+        [JsonProperty("analyzer_platform")]
+        public string AnalyzerVersion { get; set; }
+
+        [JsonProperty("platform")]
+        public string Platform { get; set; }
+
+        [JsonProperty("status_code")]
+        public int StatusCode { get; set; }
+
+        [JsonProperty("detailed_status")]
+        public string DetailedStatus { get; set; }
+
+        [JsonProperty("timestamp")]
+        public long Timestamp { get; set; }
+
+        [JsonProperty("analysis_time")]
+        public double AnalysisTime { get; set; }
+
+        [JsonProperty("input_process")]
+        public string InputProcess { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AnalysisSection.cs
+++ b/SpotifyAPI.Core/Web/Models/AnalysisSection.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisSection
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+
+        [JsonProperty("loudness")]
+        public double Loudness { get; set; }
+
+        [JsonProperty("tempo")]
+        public double Tempo { get; set; }
+
+        [JsonProperty("tempo_confidence")]
+        public double TempoConfidence { get; set; }
+
+        [JsonProperty("key")]
+        public int Key { get; set; }
+
+        [JsonProperty("key_confidence")]
+        public double KeyConfidence { get; set; }
+
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+
+        [JsonProperty("mode_confidence")]
+        public double ModeConfidence { get; set; }
+
+        [JsonProperty("time_signature")]
+        public int TimeSignature { get; set; }
+
+        [JsonProperty("time_signature_confidence")]
+        public double TimeSignatureConfidence { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AnalysisSegment.cs
+++ b/SpotifyAPI.Core/Web/Models/AnalysisSegment.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisSegment
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+
+        [JsonProperty("loudness_start")]
+        public double LoudnessStart { get; set; }
+
+        [JsonProperty("loudness_max_time")]
+        public double LoudnessMaxTime { get; set; }
+
+        [JsonProperty("loudness_max")]
+        public double LoudnessMax { get; set; }
+
+        [JsonProperty("loudness_end")]
+        public double LoudnessEnd { get; set; }
+
+        [JsonProperty("pitches")]
+        public List<double> Pitches { get; set; }
+
+        [JsonProperty("timbre")]
+        public List<double> Timbre { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AnalysisTimeSlice.cs
+++ b/SpotifyAPI.Core/Web/Models/AnalysisTimeSlice.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisTimeSlice
+    {
+        [JsonProperty("start")]
+        public double Start { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("confidence")]
+        public double Confidence { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AnalysisTrack.cs
+++ b/SpotifyAPI.Core/Web/Models/AnalysisTrack.cs
@@ -1,0 +1,86 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AnalysisTrack
+    {
+        [JsonProperty("num_samples")]
+        public int NumSamples { get; set; }
+
+        [JsonProperty("duration")]
+        public double Duration { get; set; }
+
+        [JsonProperty("sample_md5")]
+        public string SampleMD5 { get; set; }
+
+        [JsonProperty("offset_seconds")]
+        public double OffsetSeconds { get; set; }
+
+        [JsonProperty("window_seconds")]
+        public double WindowSeconds { get; set; }
+
+        [JsonProperty("analysis_sample_rate")]
+        public int AnalysisSampleRate { get; set; }
+
+        [JsonProperty("analysis_channels")]
+        public int AnalysisChannels { get; set; }
+
+        [JsonProperty("end_of_fade_in")]
+        public double EndOfFadeIn { get; set; }
+
+        [JsonProperty("start_of_fade_out")]
+        public double StartOfFadeOut { get; set; }
+
+        [JsonProperty("loudness")]
+        public double Loudness { get; set; }
+
+        [JsonProperty("tempo")]
+        public double Tempo { get; set; }
+
+        [JsonProperty("tempo_confidence")]
+        public double TempoConfidence { get; set; }
+
+        [JsonProperty("time_signature")]
+        public double TimeSignature { get; set; }
+
+        [JsonProperty("time_signature_confidence")]
+        public double TimeSignatureConfidence { get; set; }
+
+        [JsonProperty("key")]
+        public int Key { get; set; }
+
+        [JsonProperty("key_confidence")]
+        public double KeyConfidence { get; set; }
+
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+
+        [JsonProperty("mode_confidence")]
+        public double ModeConfidence { get; set; }
+
+        [JsonProperty("codestring")]
+        public string Codestring { get; set; }
+
+        [JsonProperty("code_version")]
+        public double CodeVersion { get; set; }
+
+        [JsonProperty("echoprintstring")]
+        public string Echoprintstring { get; set; }
+
+        [JsonProperty("echoprint_version")]
+        public double EchoprintVersion { get; set; }
+
+        [JsonProperty("synchstring")]
+        public string Synchstring { get; set; }
+
+        [JsonProperty("synch_version")]
+        public double SynchVersion { get; set; }
+
+        [JsonProperty("rhythmstring")]
+        public string Rhythmstring { get; set; }
+
+        [JsonProperty("rhythm_version")]
+        public double RhythmVersion { get; set; }
+
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/ArrayResponse.cs
+++ b/SpotifyAPI.Core/Web/Models/ArrayResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class ListResponse<T> : BasicModel
+    {
+        public List<T> List { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AudioAnalysis.cs
+++ b/SpotifyAPI.Core/Web/Models/AudioAnalysis.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AudioAnalysis : BasicModel
+    {
+        [JsonProperty("bars")]
+        public List<AnalysisTimeSlice> Bars { get; set; }
+
+        [JsonProperty("beats")]
+        public List<AnalysisTimeSlice> Beats { get; set; }
+
+        [JsonProperty("meta")]
+        public AnalysisMeta Meta { get; set; }
+
+        [JsonProperty("sections")]
+        public List<AnalysisSection> Sections { get; set; }
+
+        [JsonProperty("segments")]
+        public List<AnalysisSegment> Segments { get; set; }
+
+        [JsonProperty("tatums")]
+        public List<AnalysisTimeSlice> Tatums { get; set; }
+
+        [JsonProperty("track")]
+        public AnalysisTrack Track { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AudioFeatures.cs
+++ b/SpotifyAPI.Core/Web/Models/AudioFeatures.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AudioFeatures : BasicModel
+    {
+        [JsonProperty("acousticness")]
+        public float Acousticness { get; set; }
+
+        [JsonProperty("analysis_url")]
+        public string AnalysisUrl { get; set; }
+
+        [JsonProperty("danceability")]
+        public float Danceability { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int DurationMs { get; set; }
+
+        [JsonProperty("energy")]
+        public float Energy { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("instrumentalness")]
+        public float Instrumentalness { get; set; }
+
+        [JsonProperty("key")]
+        public int Key { get; set; }
+
+        [JsonProperty("liveness")]
+        public float Liveness { get; set; }
+
+        [JsonProperty("loudness")]
+        public float Loudness { get; set; }
+
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+
+        [JsonProperty("speechiness")]
+        public float Speechiness { get; set; }
+
+        [JsonProperty("tempo")]
+        public float Tempo { get; set; }
+
+        [JsonProperty("time_signature")]
+        public int TimeSignature { get; set; }
+
+        [JsonProperty("track_href")]
+        public string TrackHref { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("valence")]
+        public float Valence { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/AvailabeDevices.cs
+++ b/SpotifyAPI.Core/Web/Models/AvailabeDevices.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class AvailabeDevices : BasicModel
+    {
+        [JsonProperty("devices")]
+        public List<Device> Devices { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/BasicModel.cs
+++ b/SpotifyAPI.Core/Web/Models/BasicModel.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Net;
+
+namespace SpotifyAPI.Web.Models
+{
+    public abstract class BasicModel
+    {
+        [JsonProperty("error")]
+        public Error Error { get; set; }
+
+        private ResponseInfo _info;
+
+        public bool HasError() => Error != null;
+
+        internal void AddResponseInfo(ResponseInfo info) => _info = info;
+
+        public string Header(string key) => _info.Headers?.Get(key);
+
+        public WebHeaderCollection Headers() => _info.Headers;
+
+        public HttpStatusCode StatusCode() => _info.StatusCode;
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Category.cs
+++ b/SpotifyAPI.Core/Web/Models/Category.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Category : BasicModel
+    {
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("icons")]
+        public List<Image> Icons { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/CategoryList.cs
+++ b/SpotifyAPI.Core/Web/Models/CategoryList.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class CategoryList : BasicModel
+    {
+        [JsonProperty("categories")]
+        public Paging<Category> Categories { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/CategoryPlaylist.cs
+++ b/SpotifyAPI.Core/Web/Models/CategoryPlaylist.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class CategoryPlaylist : BasicModel
+    {
+        [JsonProperty("playlists")]
+        public Paging<SimplePlaylist> Playlists { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/CursorPaging.cs
+++ b/SpotifyAPI.Core/Web/Models/CursorPaging.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class CursorPaging<T> : BasicModel
+    {
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("items")]
+        public List<T> Items { get; set; }
+
+        [JsonProperty("limit")]
+        public int Limit { get; set; }
+
+        [JsonProperty("next")]
+        public string Next { get; set; }
+
+        [JsonProperty("cursors")]
+        public Cursor Cursors { get; set; }
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Device.cs
+++ b/SpotifyAPI.Core/Web/Models/Device.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Device
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("is_active")]
+        public bool IsActive { get; set; }
+
+        [JsonProperty("is_restricted")]
+        public bool IsRestricted { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("volume_percent")]
+        public int VolumePercent { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FeaturedPlaylists.cs
+++ b/SpotifyAPI.Core/Web/Models/FeaturedPlaylists.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FeaturedPlaylists : BasicModel
+    {
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        [JsonProperty("playlists")]
+        public Paging<SimplePlaylist> Playlists { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FollowedArtists.cs
+++ b/SpotifyAPI.Core/Web/Models/FollowedArtists.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FollowedArtists : BasicModel
+    {
+        [JsonProperty("artists")]
+        public CursorPaging<FullArtist> Artists { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FullAlbum.cs
+++ b/SpotifyAPI.Core/Web/Models/FullAlbum.cs
@@ -1,0 +1,63 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FullAlbum : BasicModel
+    {
+        [JsonProperty("album_type")]
+        public string AlbumType { get; set; }
+
+        [JsonProperty("artists")]
+        public List<SimpleArtist> Artists { get; set; }
+
+        [JsonProperty("available_markets")]
+        public List<string> AvailableMarkets { get; set; }
+
+        [JsonProperty("copyrights")]
+        public List<Copyright> Copyrights { get; set; }
+
+        [JsonProperty("external_ids")]
+        public Dictionary<string, string> ExternalIds { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("genres")]
+        public List<string> Genres { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+        
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("popularity")]
+        public int Popularity { get; set; }
+
+        [JsonProperty("release_date")]
+        public string ReleaseDate { get; set; }
+
+        [JsonProperty("release_date_precision")]
+        public string ReleaseDatePrecision { get; set; }
+
+        [JsonProperty("tracks")]
+        public Paging<SimpleTrack> Tracks { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FullArtist.cs
+++ b/SpotifyAPI.Core/Web/Models/FullArtist.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FullArtist : BasicModel
+    {
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("followers")]
+        public Followers Followers { get; set; }
+
+        [JsonProperty("genres")]
+        public List<string> Genres { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("popularity")]
+        public int Popularity { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FullPlaylist.cs
+++ b/SpotifyAPI.Core/Web/Models/FullPlaylist.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FullPlaylist : BasicModel
+    {
+        [JsonProperty("collaborative")]
+        public Boolean Collaborative { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("followers")]
+        public Followers Followers { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("owner")]
+        public PublicProfile Owner { get; set; }
+
+        [JsonProperty("public")]
+        public Boolean Public { get; set; }
+
+        [JsonProperty("snapshot_id")]
+        public string SnapshotId { get; set; }
+
+        [JsonProperty("tracks")]
+        public Paging<PlaylistTrack> Tracks { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/FullTrack.cs
+++ b/SpotifyAPI.Core/Web/Models/FullTrack.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FullTrack : BasicModel
+    {
+        [JsonProperty("album")]
+        public SimpleAlbum Album { get; set; }
+
+        [JsonProperty("artists")]
+        public List<SimpleArtist> Artists { get; set; }
+
+        [JsonProperty("available_markets")]
+        public List<string> AvailableMarkets { get; set; }
+
+        [JsonProperty("disc_number")]
+        public int DiscNumber { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int DurationMs { get; set; }
+
+        [JsonProperty("explicit")]
+        public Boolean Explicit { get; set; }
+
+        [JsonProperty("external_ids")]
+        public Dictionary<string, string> ExternalIds { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("popularity")]
+        public int Popularity { get; set; }
+
+        [JsonProperty("preview_url")]
+        public string PreviewUrl { get; set; }
+
+        [JsonProperty("track_number")]
+        public int TrackNumber { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        /// <summary>
+        ///     Only filled when the "market"-parameter was supplied!
+        /// </summary>
+        [JsonProperty("is_playable")]
+        public Boolean? IsPlayable { get; set; }
+
+        /// <summary>
+        ///     Only filled when the "market"-parameter was supplied!
+        /// </summary>
+        [JsonProperty("linked_from")]
+        public LinkedFrom LinkedFrom { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/GeneralModels.cs
+++ b/SpotifyAPI.Core/Web/Models/GeneralModels.cs
@@ -1,0 +1,159 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Image
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("width")]
+        public int Width { get; set; }
+
+        [JsonProperty("height")]
+        public int Height { get; set; }
+    }
+
+    public class ErrorResponse : BasicModel
+    {
+    }
+
+    public class Error
+    {
+        [JsonProperty("status")]
+        public int Status { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+
+    public class PlaylistTrackCollection
+    {
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+    }
+
+    public class Followers
+    {
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+    }
+
+    public class PlaylistTrack
+    {
+        [JsonProperty("added_at")]
+        public DateTime AddedAt { get; set; }
+
+        [JsonProperty("added_by")]
+        public PublicProfile AddedBy { get; set; }
+
+        [JsonProperty("track")]
+        public FullTrack Track { get; set; }
+
+        [JsonProperty("is_local")]
+        public Boolean IsLocal { get; set; }
+    }
+
+    public class DeleteTrackUri
+    {
+        /// <summary>
+        ///     Delete-Track Wrapper
+        /// </summary>
+        /// <param name="uri">An Spotify-URI</param>
+        /// <param name="positions">Optional positions</param>
+        public DeleteTrackUri(string uri, params int[] positions)
+        {
+            Positions = positions.ToList();
+            Uri = uri;
+        }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("positions")]
+        public List<int> Positions { get; set; }
+
+        public bool ShouldSerializePositions()
+        {
+            return (Positions.Count > 0);
+        }
+    }
+
+    public class Copyright
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+
+    public class LinkedFrom
+    {
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+
+    public class SavedTrack
+    {
+        [JsonProperty("added_at")]
+        public DateTime AddedAt { get; set; }
+
+        [JsonProperty("track")]
+        public FullTrack Track { get; set; }
+    }
+
+    public class SavedAlbum
+    {
+        [JsonProperty("added_at")]
+        public DateTime AddedAt { get; set; }
+
+        [JsonProperty("album")]
+        public FullAlbum Album { get; set; }
+    }
+
+    public class Cursor
+    {
+        [JsonProperty("after")]
+        public string After { get; set; }
+
+        [JsonProperty("before")]
+        public string Before { get; set; }
+    }
+
+    public class Context
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/NewAlbumReleases.cs
+++ b/SpotifyAPI.Core/Web/Models/NewAlbumReleases.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class NewAlbumReleases : BasicModel
+    {
+        [JsonProperty("albums")]
+        public Paging<SimpleAlbum> Albums { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Paging.cs
+++ b/SpotifyAPI.Core/Web/Models/Paging.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Paging<T> : BasicModel
+    {
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("items")]
+        public List<T> Items { get; set; }
+
+        [JsonProperty("limit")]
+        public int Limit { get; set; }
+
+        [JsonProperty("next")]
+        public string Next { get; set; }
+
+        [JsonProperty("offset")]
+        public int Offset { get; set; }
+
+        [JsonProperty("previous")]
+        public string Previous { get; set; }
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        public bool HasNextPage()
+        {
+            return Next != null;
+        }
+
+        public bool HasPreviousPage()
+        {
+            return Next != null;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/PlayHistory.cs
+++ b/SpotifyAPI.Core/Web/Models/PlayHistory.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class PlayHistory : BasicModel
+    {
+        [JsonProperty("track")]
+        public SimpleTrack Track { get; set; }
+
+        [JsonProperty("played_at")]
+        public DateTime PlayedAt { get; set; }
+
+        [JsonProperty("context")]
+        public Context Context { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/PlaybackContext.cs
+++ b/SpotifyAPI.Core/Web/Models/PlaybackContext.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using SpotifyAPI.Web.Enums;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class PlaybackContext : BasicModel
+    {
+        [JsonProperty("device")]
+        public Device Device { get; set; }
+
+        [JsonProperty("repeat_state")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RepeatState RepeatState { get; set; }
+
+        [JsonProperty("shuffle_state")]
+        public bool ShuffleState { get; set; }
+
+        [JsonProperty("context")]
+        public Context Context { get; set; }
+
+        [JsonProperty("timestamp")]
+        public long Timestamp { get; set; }
+
+        [JsonProperty("progress_ms")]
+        public int ProgressMs { get; set; }
+
+        [JsonProperty("is_playing")]
+        public bool IsPlaying { get; set; }
+
+        [JsonProperty("item")]
+        public FullTrack Item { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/PrivateProfile.cs
+++ b/SpotifyAPI.Core/Web/Models/PrivateProfile.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class PrivateProfile : BasicModel
+    {
+        [JsonProperty("birthdate")]
+        public string Birthdate { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("followers")]
+        public Followers Followers { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("product")]
+        public string Product { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/PublicProfile.cs
+++ b/SpotifyAPI.Core/Web/Models/PublicProfile.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class PublicProfile : BasicModel
+    {
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("followers")]
+        public Followers Followers { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/RecommendationSeed .cs
+++ b/SpotifyAPI.Core/Web/Models/RecommendationSeed .cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class RecommendationSeed
+    {
+        [JsonProperty("afterFilteringSize")]
+        public int AfterFilteringSize { get; set; }
+
+        [JsonProperty("afterRelinkingSize")]
+        public int AfterRelinkingSize { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("initialPoolSize")]
+        public int InitialPoolSize { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/RecommendationSeedGenres.cs
+++ b/SpotifyAPI.Core/Web/Models/RecommendationSeedGenres.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class RecommendationSeedGenres : BasicModel
+    {
+         [JsonProperty("genres")]
+         public List<string> Genres { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Recommendations.cs
+++ b/SpotifyAPI.Core/Web/Models/Recommendations.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Recommendations : BasicModel
+    {
+        [JsonProperty("seeds")]
+        public List<RecommendationSeed> Seeds { get; set; }
+
+        [JsonProperty("tracks")]
+        public List<SimpleTrack> Tracks { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/ResponseInfo.cs
+++ b/SpotifyAPI.Core/Web/Models/ResponseInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Net;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class ResponseInfo
+    {
+        public WebHeaderCollection Headers { get; set; }
+
+        public HttpStatusCode StatusCode { get; set; }
+
+        public static readonly ResponseInfo Empty = new ResponseInfo();
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SearchItem.cs
+++ b/SpotifyAPI.Core/Web/Models/SearchItem.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SearchItem : BasicModel
+    {
+        [JsonProperty("artists")]
+        public Paging<FullArtist> Artists { get; set; }
+
+        [JsonProperty("albums")]
+        public Paging<SimpleAlbum> Albums { get; set; }
+
+        [JsonProperty("tracks")]
+        public Paging<FullTrack> Tracks { get; set; }
+
+        [JsonProperty("playlists")]
+        public Paging<SimplePlaylist> Playlists { get; set; } 
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SeveralAlbums.cs
+++ b/SpotifyAPI.Core/Web/Models/SeveralAlbums.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SeveralAlbums : BasicModel
+    {
+        [JsonProperty("albums")]
+        public List<FullAlbum> Albums { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SeveralArtists.cs
+++ b/SpotifyAPI.Core/Web/Models/SeveralArtists.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SeveralArtists : BasicModel
+    {
+        [JsonProperty("artists")]
+        public List<FullArtist> Artists { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SeveralAudioFeatures.cs
+++ b/SpotifyAPI.Core/Web/Models/SeveralAudioFeatures.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SeveralAudioFeatures : BasicModel
+    {
+         [JsonProperty("audio_features")]
+         public List<AudioFeatures> AudioFeatures { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SeveralTracks.cs
+++ b/SpotifyAPI.Core/Web/Models/SeveralTracks.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SeveralTracks : BasicModel
+    {
+        [JsonProperty("tracks")]
+        public List<FullTrack> Tracks { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SimpleAlbum.cs
+++ b/SpotifyAPI.Core/Web/Models/SimpleAlbum.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimpleAlbum : BasicModel
+    {
+        [JsonProperty("album_type")]
+        public string AlbumType { get; set; }
+
+        [JsonProperty("available_markets")]
+        public List<string> AvailableMarkets { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("release_date")]
+        public string ReleaseDate { get; set; }
+
+        [JsonProperty("release_date_precision")]
+        public string ReleaseDatePrecision { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SimpleArtist.cs
+++ b/SpotifyAPI.Core/Web/Models/SimpleArtist.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimpleArtist : BasicModel
+    {
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SimplePlaylist.cs
+++ b/SpotifyAPI.Core/Web/Models/SimplePlaylist.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimplePlaylist : BasicModel
+    {
+        [JsonProperty("collaborative")]
+        public Boolean Collaborative { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("owner")]
+        public PublicProfile Owner { get; set; }
+
+        [JsonProperty("public")]
+        public Boolean Public { get; set; }
+
+        [JsonProperty("snapshot_id")]
+        public string SnapshotId { get; set; }
+
+        [JsonProperty("tracks")]
+        public PlaylistTrackCollection Tracks { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/SimpleTrack.cs
+++ b/SpotifyAPI.Core/Web/Models/SimpleTrack.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimpleTrack : BasicModel
+    {
+        [JsonProperty("artists")]
+        public List<SimpleArtist> Artists { get; set; }
+
+        [JsonProperty("available_markets")]
+        public List<string> AvailableMarkets { get; set; }
+
+        [JsonProperty("disc_number")]
+        public int DiscNumber { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int DurationMs { get; set; }
+
+        [JsonProperty("explicit")]
+        public Boolean Explicit { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("preview_url")]
+        public string PreviewUrl { get; set; }
+
+        [JsonProperty("track_number")]
+        public int TrackNumber { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Snapshot.cs
+++ b/SpotifyAPI.Core/Web/Models/Snapshot.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Snapshot : BasicModel
+    {
+        [JsonProperty("snapshot_id")]
+        public string SnapshotId { get; set; }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/Token.cs
+++ b/SpotifyAPI.Core/Web/Models/Token.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class Token
+    {
+        public Token()
+        {
+            CreateDate = DateTime.Now;
+        }
+
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+
+        [JsonProperty("error")]
+        public string Error { get; set; }
+
+        [JsonProperty("error_description")]
+        public string ErrorDescription { get; set; }
+
+        public DateTime CreateDate { get; set; }
+
+        /// <summary>
+        ///     Checks if the token has expired
+        /// </summary>
+        /// <returns></returns>
+        public Boolean IsExpired()
+        {
+            return CreateDate.Add(TimeSpan.FromSeconds(ExpiresIn)) <= DateTime.Now;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/Models/TuneableTrack.cs
+++ b/SpotifyAPI.Core/Web/Models/TuneableTrack.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class TuneableTrack
+    {
+        [String("acousticness")]
+        public float? Acousticness { get; set; }
+
+        [String("danceability")]
+        public float? Danceability { get; set; }
+
+        [String("duration_ms")]
+        public int? DurationMs { get; set; }
+
+        [String("energy")]
+        public float? Energy { get; set; }
+
+        [String("instrumentalness")]
+        public float? Instrumentalness { get; set; }
+
+        [String("key")]
+        public int? Key { get; set; }
+
+        [String("liveness")]
+        public float? Liveness { get; set; }
+
+        [String("loudness")]
+        public float? Loudness { get; set; }
+
+        [String("mode")]
+        public int? Mode { get; set; }
+
+        [String("popularity")]
+        public int? Popularity { get; set; }
+
+        [String("speechiness")]
+        public float? Speechiness { get; set; }
+
+        [String("tempo")]
+        public float? Tempo { get; set; }
+
+        [String("time_signature")]
+        public int? TimeSignature { get; set; }
+
+        [String("valence")]
+        public float? Valence { get; set; }
+
+        public string BuildUrlParams(string prefix)
+        {
+            List<string> urlParams = new List<string>();
+            foreach (PropertyInfo info in GetType().GetProperties())
+            {
+                object value = info.GetValue(this);
+                string name = info.GetCustomAttribute<StringAttribute>()?.Text;
+                if(name == null || value == null)
+                    continue;
+                if (value is float)
+                    urlParams.Add($"{prefix}_{name}={((float)value).ToString(CultureInfo.InvariantCulture)}");
+                else
+                    urlParams.Add($"{prefix}_{name}={value}");
+            }
+            if (urlParams.Count > 0)
+                return "&" + string.Join("&", urlParams);
+            return "";
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/SimpleHttpServer.cs
+++ b/SpotifyAPI.Core/Web/SimpleHttpServer.cs
@@ -1,0 +1,370 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+// offered to the public domain for any use with no restriction
+// and also with no warranty of any kind, please enjoy. - David Jeske.
+
+// simple HTTP explanation
+// http://www.jmarshall.com/easy/http/
+
+namespace SpotifyAPI.Web
+{
+    public class HttpProcessor : IDisposable
+    {
+        private const int MaxPostSize = 10 * 1024 * 1024; // 10MB
+        private const int BufSize = 4096;
+        private readonly HttpServer _srv;
+        private Stream _inputStream;
+        private readonly Hashtable _httpHeaders = new Hashtable();
+        private string _httpMethod;
+        public string HttpProtocolVersionstring;
+        public string HttpUrl;
+        public StreamWriter OutputStream;
+
+        public HttpProcessor(HttpServer srv)
+        {
+            _srv = srv;
+        }
+
+        private string[] GetIncomingRequest(Stream inputStream)
+        {
+            var buffer = new byte[4096];
+            var read = inputStream.Read(buffer, 0, buffer.Length);
+
+            var inputData = Encoding.ASCII.GetString(buffer.Take(read).ToArray());
+            return inputData.Split('\n').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+        }
+
+        public void Process(TcpClient socket)
+        {
+            // we can't use a StreamReader for input, because it buffers up extra data on us inside it's
+            // "processed" view of the world, and we want the data raw after the headers
+            _inputStream = new BufferedStream(socket.GetStream());
+
+            // we probably shouldn't be using a streamwriter for all output from handlers either
+            OutputStream = new StreamWriter(new BufferedStream(socket.GetStream()));
+            try
+            {
+                var requestLines = GetIncomingRequest(_inputStream);
+
+                ParseRequest(requestLines.First());
+                ReadHeaders(requestLines.Skip(1));
+
+                if (_httpMethod.Equals("GET"))
+                {
+                    HandleGetRequest();
+                }
+                else if (_httpMethod.Equals("POST"))
+                {
+                    HandlePostRequest();
+                }
+            }
+            catch (Exception)
+            {
+                WriteFailure();
+            }
+            OutputStream.Flush();
+            _inputStream = null;
+            OutputStream = null;
+        }
+
+        public void ParseRequest(string request)
+        {
+            string[] tokens = request.Split(' ');
+            if (tokens.Length < 2)
+            {
+                throw new Exception("Invalid HTTP request line");
+            }
+            _httpMethod = tokens[0].ToUpper();
+            HttpUrl = tokens[1];
+        }
+
+        public void ReadHeaders(IEnumerable<string> requestLines)
+        {
+            foreach(var line in requestLines)
+            {
+                if (string.IsNullOrEmpty(line))
+                {
+                    return;
+                }
+
+                int separator = line.IndexOf(':');
+                if (separator == -1)
+                {
+                    throw new Exception("Invalid HTTP header line: " + line);
+                }
+                string name = line.Substring(0, separator);
+                int pos = separator + 1;
+                while ((pos < line.Length) && (line[pos] == ' '))
+                {
+                    pos++; // strip any spaces
+                }
+
+                string value = line.Substring(pos, line.Length - pos);
+                _httpHeaders[name] = value;
+            }
+        }
+
+        public void HandleGetRequest()
+        {
+            _srv.HandleGetRequest(this);
+        }
+
+        public void HandlePostRequest()
+        {
+            // this post data processing just reads everything into a memory stream.
+            // this is fine for smallish things, but for large stuff we should really
+            // hand an input stream to the request processor. However, the input stream
+            // we hand him needs to let him see the "end of the stream" at this content
+            // length, because otherwise he won't know when he's seen it all!
+
+            MemoryStream ms = new MemoryStream();
+            if (_httpHeaders.ContainsKey("Content-Length"))
+            {
+                var contentLen = Convert.ToInt32(_httpHeaders["Content-Length"]);
+                if (contentLen > MaxPostSize)
+                {
+                    throw new Exception($"POST Content-Length({contentLen}) too big for this simple server");
+                }
+                byte[] buf = new byte[BufSize];
+                int toRead = contentLen;
+                while (toRead > 0)
+                {
+                    int numread = _inputStream.Read(buf, 0, Math.Min(BufSize, toRead));
+                    if (numread == 0)
+                    {
+                        if (toRead == 0)
+                        {
+                            break;
+                        }
+                        throw new Exception("Client disconnected during post");
+                    }
+                    toRead -= numread;
+                    ms.Write(buf, 0, numread);
+                }
+                ms.Seek(0, SeekOrigin.Begin);
+            }
+            _srv.HandlePostRequest(this, new StreamReader(ms));
+        }
+
+        public void WriteSuccess(string contentType = "text/html")
+        {
+            OutputStream.WriteLine("HTTP/1.0 200 OK");
+            OutputStream.WriteLine("Content-Type: " + contentType);
+            OutputStream.WriteLine("Connection: close");
+            OutputStream.WriteLine("");
+        }
+
+        public void WriteFailure()
+        {
+            OutputStream.WriteLine("HTTP/1.0 404 File not found");
+            OutputStream.WriteLine("Connection: close");
+            OutputStream.WriteLine("");
+        }
+
+        public void Dispose()
+        {
+
+        }
+    }
+
+    public abstract class HttpServer : IDisposable
+    {
+        private TcpListener _listener;
+        protected int Port;
+
+        protected HttpServer(int port)
+        {
+            IsActive = true;
+            Port = port;
+        }
+
+        public bool IsActive { get; set; }
+
+        public void Dispose()
+        {
+            IsActive = false;
+            _listener.Stop();
+            GC.SuppressFinalize(this);
+        }
+
+        public void Listen()
+        {
+            try
+            {
+                _listener = new TcpListener(IPAddress.Any, Port);
+                _listener.Start();
+
+                _listener.BeginAcceptTcpClient(AcceptTcpConnection, _listener);
+
+            }
+            catch (SocketException e)
+            {
+                if (e.ErrorCode != 10004) //Ignore 10004, which is thrown when the thread gets terminated
+                    throw;
+            }
+        }
+
+        private void AcceptTcpConnection(IAsyncResult ar)
+        {
+            TcpListener listener = (TcpListener)ar.AsyncState;
+            try
+            {
+                var tcpCLient = listener.EndAcceptTcpClient(ar);
+                using (HttpProcessor processor = new HttpProcessor(this))
+                {
+                    processor.Process(tcpCLient);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore
+            }
+
+            if (!IsActive)
+                return;
+            //listener.Start();
+            listener.BeginAcceptTcpClient(AcceptTcpConnection, listener);
+        }
+
+        public abstract void HandleGetRequest(HttpProcessor p);
+
+        public abstract void HandlePostRequest(HttpProcessor p, StreamReader inputData);
+    }
+
+    public class AuthEventArgs
+    {
+        //Code can be an AccessToken or an Exchange Code
+        public string Code { get; set; }
+
+        public string TokenType { get; set; }
+        public string State { get; set; }
+        public string Error { get; set; }
+        public int ExpiresIn { get; set; }
+    }
+
+    public class SimpleHttpServer : HttpServer
+    {
+        private readonly AuthType _type;
+
+        public delegate void AuthEventHandler(AuthEventArgs e);
+
+        public event AuthEventHandler OnAuth;
+
+        public SimpleHttpServer(int port, AuthType type) : base(port)
+        {
+            _type = type;
+        }
+
+        public override void HandleGetRequest(HttpProcessor p)
+        {
+            p.WriteSuccess();
+            if (p.HttpUrl == "/favicon.ico")
+                return;
+
+            Thread t;
+            if (_type == AuthType.Authorization)
+            {
+                string url = p.HttpUrl;
+                url = url.Substring(2, url.Length - 2);
+                NameValueCollection col = HttpUtility.ParseQueryString(url);
+                if (col.Keys.Get(0) != "code")
+                {
+                     p.OutputStream.WriteLine("<html><body><h1>Spotify Auth canceled!</h1></body></html>");
+                    t = new Thread(o =>
+                    {
+                        OnAuth?.Invoke(new AuthEventArgs()
+                        {
+                            State = col.Get(1),
+                            Error = col.Get(0),
+                        });
+                    });
+                }
+                else
+                {
+                    p.OutputStream.WriteLine("<html><body><h1>Spotify Auth successful!</h1><script>window.close();</script></body></html>");
+                    t = new Thread(o =>
+                    {
+                        OnAuth?.Invoke(new AuthEventArgs()
+                        {
+                            Code = col.Get(0),
+                            State = col.Get(1)
+                        });
+                    });
+                }
+            }
+            else
+            {
+                if (p.HttpUrl == "/")
+                {
+                    p.OutputStream.WriteLine("<html><body>" +
+                                             "<script>" +
+                                             "" +
+                                             "var hashes = window.location.hash;" +
+                                             "hashes = hashes.replace('#','&');" +
+                                             "window.location = hashes" +
+                                             "</script>" +
+                                             "<h1>Spotify Auth successful!<br>Please copy the URL and paste it into the application</h1></body></html>");
+                    p.OutputStream.Flush();
+                    p.OutputStream.Close();
+                    return;
+                }
+                string url = p.HttpUrl;
+                url = url.Substring(2, url.Length - 2);
+                NameValueCollection col = HttpUtility.ParseQueryString(url);
+                if (col.Keys.Get(0) != "access_token")
+                {
+                    p.OutputStream.WriteLine("<html><body><h1>Spotify Auth canceled!</h1></body></html>");
+                    t = new Thread(o =>
+                    {
+                        OnAuth?.Invoke(new AuthEventArgs()
+                        {
+                            Error = col.Get(0),
+                            State = col.Get(1)
+                        });
+                    });
+                }
+                else
+                {
+                    p.OutputStream.WriteLine("<html><body><h1>Spotify Auth successful!</h1><script>window.close();</script></body></html>");
+                    t = new Thread(o =>
+                    {
+                        OnAuth?.Invoke(new AuthEventArgs()
+                        {
+                            Code = col.Get(0),
+                            TokenType = col.Get(1),
+                            ExpiresIn = Convert.ToInt32(col.Get(2)),
+                            State = col.Get(3)
+                        });
+                    });
+                    p.OutputStream.Flush();
+                    p.OutputStream.Close();
+                }
+            }
+
+            
+            t.Start();
+        }
+
+        public override void HandlePostRequest(HttpProcessor p, StreamReader inputData)
+        {
+            p.WriteSuccess();
+        }
+    }
+
+    public enum AuthType
+    {
+        Implicit,
+        Authorization
+    }
+}

--- a/SpotifyAPI.Core/Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Core/Web/SpotifyWebAPI.cs
@@ -1,0 +1,2255 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SpotifyAPI.Web
+{
+    // ReSharper disable once InconsistentNaming
+    public sealed class SpotifyWebAPI : IDisposable
+    {
+        [Obsolete("This Property will be removed soon. Please use SpotifyWebBuilder.APIBase")]
+        public const string APIBase = SpotifyWebBuilder.APIBase;
+
+        private readonly SpotifyWebBuilder _builder;
+
+        public SpotifyWebAPI() : this(null)
+        {
+        }
+
+        public SpotifyWebAPI(ProxyConfig proxyConfig)
+        {
+            _builder = new SpotifyWebBuilder();
+            UseAuth = true;
+            WebClient = new SpotifyWebClient
+            {
+                JsonSettings =
+                    new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore,
+                        TypeNameHandling = TypeNameHandling.All
+                    },
+                ProxyConfig = proxyConfig
+            };
+        }
+
+        public void Dispose()
+        {
+            WebClient.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        #region Configuration
+
+        /// <summary>
+        ///     The type of the <see cref="AccessToken"/>
+        /// </summary>
+        public string TokenType { get; set; }
+
+        /// <summary>
+        ///     A valid token issued by spotify. Used only when <see cref="UseAuth"/> is true
+        /// </summary>
+        public string AccessToken { get; set; }
+
+        /// <summary>
+        ///     If true, an authorization header based on <see cref="TokenType"/> and <see cref="AccessToken"/> will be used
+        /// </summary>
+        public bool UseAuth { get; set; }
+
+        /// <summary>
+        ///     A custom WebClient, used for Unit-Testing
+        /// </summary>
+        public IClient WebClient { get; set; }
+
+
+        /// <summary>
+        ///     Specifies after how many miliseconds should a failed request be retried.
+        /// </summary>
+        public int RetryAfter { get; set; } = 50;
+
+        /// <summary>
+        ///     Should a failed request (specified by <see cref="RetryErrorCodes"/> be automatically retried or not.
+        /// </summary>
+        public bool UseAutoRetry { get; set; } = false;
+
+        /// <summary>
+        ///     Maximum number of tries for one failed request.
+        /// </summary>
+        public int RetryTimes { get; set; } = 10;
+
+        /// <summary>
+        ///     Error codes that will trigger auto-retry if <see cref="UseAutoRetry"/> is enabled.
+        /// </summary>
+        public IEnumerable<int> RetryErrorCodes { get; set; } = new[] { 500, 502, 503 };
+
+        #endregion Configuration
+
+        #region Search
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists, albums, tracks or playlists that match a keyword string.
+        /// </summary>
+        /// <param name="q">The search query's keywords (and optional field filters and operators), for example q=roadhouse+blues.</param>
+        /// <param name="type">A list of item types to search across.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first result to return. Default: 0</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code or the string from_token.</param>
+        /// <returns></returns>
+        public SearchItem SearchItems(string q, SearchType type, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadData<SearchItem>(_builder.SearchItems(q, type, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists, albums, tracks or playlists that match a keyword string asynchronously.
+        /// </summary>
+        /// <param name="q">The search query's keywords (and optional field filters and operators), for example q=roadhouse+blues.</param>
+        /// <param name="type">A list of item types to search across.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first result to return. Default: 0</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code or the string from_token.</param>
+        /// <returns></returns>
+        public Task<SearchItem> SearchItemsAsync(string q, SearchType type, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadDataAsync<SearchItem>(_builder.SearchItems(q, type, limit, offset, market));
+        }
+
+        #endregion Search
+
+        #region Albums
+
+        /// <summary>
+        ///     Get Spotify catalog information about an album’s tracks. Optional parameters can be used to limit the number of
+        ///     tracks returned.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first track to return. Default: 0 (the first object).</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Paging<SimpleTrack> GetAlbumTracks(string id, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadData<Paging<SimpleTrack>>(_builder.GetAlbumTracks(id, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an album’s tracks asynchronously. Optional parameters can be used to limit the number of
+        ///     tracks returned.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first track to return. Default: 0 (the first object).</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Task<Paging<SimpleTrack>> GetAlbumTracksAsync(string id, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadDataAsync<Paging<SimpleTrack>>(_builder.GetAlbumTracks(id, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single album.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public FullAlbum GetAlbum(string id, string market = "")
+        {
+            return DownloadData<FullAlbum>(_builder.GetAlbum(id, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single album asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Task<FullAlbum> GetAlbumAsync(string id, string market = "")
+        {
+            return DownloadDataAsync<FullAlbum>(_builder.GetAlbum(id, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple albums identified by their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the albums. Maximum: 20 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public SeveralAlbums GetSeveralAlbums(List<string> ids, string market = "")
+        {
+            return DownloadData<SeveralAlbums>(_builder.GetSeveralAlbums(ids, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple albums identified by their Spotify IDs asynchrously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the albums. Maximum: 20 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Task<SeveralAlbums> GetSeveralAlbumsAsync(List<string> ids, string market = "")
+        {
+            return DownloadDataAsync<SeveralAlbums>(_builder.GetSeveralAlbums(ids, market));
+        }
+
+        #endregion Albums
+
+        #region Artists
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single artist identified by their unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public FullArtist GetArtist(string id)
+        {
+            return DownloadData<FullArtist>(_builder.GetArtist(id));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single artist identified by their unique Spotify ID asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public Task<FullArtist> GetArtistAsync(string id)
+        {
+            return DownloadDataAsync<FullArtist>(_builder.GetArtist(id));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists similar to a given artist. Similarity is based on analysis of the
+        ///     Spotify community’s listening history.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public SeveralArtists GetRelatedArtists(string id)
+        {
+            return DownloadData<SeveralArtists>(_builder.GetRelatedArtists(id));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists similar to a given artist asynchronously. Similarity is based on analysis of the
+        ///     Spotify community’s listening history.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public Task<SeveralArtists> GetRelatedArtistsAsync(string id)
+        {
+            return DownloadDataAsync<SeveralArtists>(_builder.GetRelatedArtists(id));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s top tracks by country.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="country">The country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <returns></returns>
+        public SeveralTracks GetArtistsTopTracks(string id, string country)
+        {
+            return DownloadData<SeveralTracks>(_builder.GetArtistsTopTracks(id, country));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s top tracks by country asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="country">The country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <returns></returns>
+        public Task<SeveralTracks> GetArtistsTopTracksAsync(string id, string country)
+        {
+            return DownloadDataAsync<SeveralTracks>(_builder.GetArtistsTopTracks(id, country));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s albums. Optional parameters can be specified in the query string
+        ///     to filter and sort the response.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="type">
+        ///     A list of keywords that will be used to filter the response. If not supplied, all album types will
+        ///     be returned
+        /// </param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first album to return. Default: 0</param>
+        /// <param name="market">
+        ///     An ISO 3166-1 alpha-2 country code. Supply this parameter to limit the response to one particular
+        ///     geographical market
+        /// </param>
+        /// <returns></returns>
+        public Paging<SimpleAlbum> GetArtistsAlbums(string id, AlbumType type = AlbumType.All, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadData<Paging<SimpleAlbum>>(_builder.GetArtistsAlbums(id, type, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s albums asynchronously. Optional parameters can be specified in the query string
+        ///     to filter and sort the response.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="type">
+        ///     A list of keywords that will be used to filter the response. If not supplied, all album types will
+        ///     be returned
+        /// </param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first album to return. Default: 0</param>
+        /// <param name="market">
+        ///     An ISO 3166-1 alpha-2 country code. Supply this parameter to limit the response to one particular
+        ///     geographical market
+        /// </param>
+        /// <returns></returns>
+        public Task<Paging<SimpleAlbum>> GetArtistsAlbumsAsync(string id, AlbumType type = AlbumType.All, int limit = 20, int offset = 0, string market = "")
+        {
+            return DownloadDataAsync<Paging<SimpleAlbum>>(_builder.GetArtistsAlbums(id, type, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for several artists based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the artists. Maximum: 50 IDs.</param>
+        /// <returns></returns>
+        public SeveralArtists GetSeveralArtists(List<string> ids)
+        {
+            return DownloadData<SeveralArtists>(_builder.GetSeveralArtists(ids));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for several artists based on their Spotify IDs asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the artists. Maximum: 50 IDs.</param>
+        /// <returns></returns>
+        public Task<SeveralArtists> GetSeveralArtistsAsync(List<string> ids)
+        {
+            return DownloadDataAsync<SeveralArtists>(_builder.GetSeveralArtists(ids));
+        }
+
+        #endregion Artists
+
+        #region Browse
+
+        /// <summary>
+        ///     Get a list of Spotify featured playlists (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="locale">
+        ///     The desired language, consisting of a lowercase ISO 639 language code and an uppercase ISO 3166-1
+        ///     alpha-2 country code, joined by an underscore.
+        /// </param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="timestamp">A timestamp in ISO 8601 format</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <remarks>AUTH NEEDED</remarks>
+        public FeaturedPlaylists GetFeaturedPlaylists(string locale = "", string country = "", DateTime timestamp = default(DateTime), int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetFeaturedPlaylists");
+            return DownloadData<FeaturedPlaylists>(_builder.GetFeaturedPlaylists(locale, country, timestamp, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of Spotify featured playlists asynchronously (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="locale">
+        ///     The desired language, consisting of a lowercase ISO 639 language code and an uppercase ISO 3166-1
+        ///     alpha-2 country code, joined by an underscore.
+        /// </param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="timestamp">A timestamp in ISO 8601 format</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<FeaturedPlaylists> GetFeaturedPlaylistsAsync(string locale = "", string country = "", DateTime timestamp = default(DateTime), int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetFeaturedPlaylists");
+            return DownloadDataAsync<FeaturedPlaylists>(_builder.GetFeaturedPlaylists(locale, country, timestamp, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public NewAlbumReleases GetNewAlbumReleases(string country = "", int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetNewAlbumReleases");
+            return DownloadData<NewAlbumReleases>(_builder.GetNewAlbumReleases(country, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of new album releases featured in Spotify asynchronously (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<NewAlbumReleases> GetNewAlbumReleasesAsync(string country = "", int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetNewAlbumReleases");
+            return DownloadDataAsync<NewAlbumReleases>(_builder.GetNewAlbumReleases(country, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter if you want to narrow the
+        ///     list of returned categories to those relevant to a particular country
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <param name="limit">The maximum number of categories to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first item to return. Default: 0 (the first object).</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public CategoryList GetCategories(string country = "", string locale = "", int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetCategories");
+            return DownloadData<CategoryList>(_builder.GetCategories(country, locale, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of categories used to tag items in Spotify asynchronously (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter if you want to narrow the
+        ///     list of returned categories to those relevant to a particular country
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <param name="limit">The maximum number of categories to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first item to return. Default: 0 (the first object).</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<CategoryList> GetCategoriesAsync(string country = "", string locale = "", int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetCategories");
+            return DownloadDataAsync<CategoryList>(_builder.GetCategories(country, locale, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter to ensure that the category
+        ///     exists for a particular country.
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Category GetCategory(string categoryId, string country = "", string locale = "")
+        {
+            return DownloadData<Category>(_builder.GetCategory(categoryId, country, locale));
+        }
+
+        /// <summary>
+        ///     Get a single category used to tag items in Spotify asynchronously (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter to ensure that the category
+        ///     exists for a particular country.
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Category> GetCategoryAsync(string categoryId, string country = "", string locale = "")
+        {
+            return DownloadDataAsync<Category>(_builder.GetCategory(categoryId, country, locale));
+        }
+
+        /// <summary>
+        ///     Get a list of Spotify playlists tagged with a particular category.
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public CategoryPlaylist GetCategoryPlaylists(string categoryId, string country = "", int limit = 20, int offset = 0)
+        {
+            return DownloadData<CategoryPlaylist>(_builder.GetCategoryPlaylists(categoryId, country, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of Spotify playlists tagged with a particular category asynchronously.
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<CategoryPlaylist> GetCategoryPlaylistsAsync(string categoryId, string country = "", int limit = 20, int offset = 0)
+        {
+            return DownloadDataAsync<CategoryPlaylist>(_builder.GetCategoryPlaylists(categoryId, country, limit, offset));
+        }
+
+        /// <summary>
+        ///     Create a playlist-style listening experience based on seed artists, tracks and genres.
+        /// </summary>
+        /// <param name="artistSeed">A comma separated list of Spotify IDs for seed artists. 
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="genreSeed">A comma separated list of any genres in the set of available genre seeds.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="trackSeed">A comma separated list of Spotify IDs for a seed track.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="target">Tracks with the attribute values nearest to the target values will be preferred.</param>
+        /// <param name="min">For each tunable track attribute, a hard floor on the selected track attribute’s value can be provided</param>
+        /// <param name="max">For each tunable track attribute, a hard ceiling on the selected track attribute’s value can be provided</param>
+        /// <param name="limit">The target size of the list of recommended tracks. Default: 20. Minimum: 1. Maximum: 100.
+        /// For seeds with unusually small pools or when highly restrictive filtering is applied, it may be impossible to generate the requested number of recommended tracks.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.
+        /// Because min_*, max_* and target_* are applied to pools before relinking, the generated results may not precisely match the filters applied.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Recommendations GetRecommendations(List<string> artistSeed = null, List<string> genreSeed = null, List<string> trackSeed = null,
+            TuneableTrack target = null, TuneableTrack min = null, TuneableTrack max = null, int limit = 20, string market = "")
+        {
+            return DownloadData<Recommendations>(_builder.GetRecommendations(artistSeed, genreSeed, trackSeed, target, min, max, limit, market));
+        }
+
+        /// <summary>
+        ///     Create a playlist-style listening experience based on seed artists, tracks and genres asynchronously.
+        /// </summary>
+        /// <param name="artistSeed">A comma separated list of Spotify IDs for seed artists. 
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="genreSeed">A comma separated list of any genres in the set of available genre seeds.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="trackSeed">A comma separated list of Spotify IDs for a seed track.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="target">Tracks with the attribute values nearest to the target values will be preferred.</param>
+        /// <param name="min">For each tunable track attribute, a hard floor on the selected track attribute’s value can be provided</param>
+        /// <param name="max">For each tunable track attribute, a hard ceiling on the selected track attribute’s value can be provided</param>
+        /// <param name="limit">The target size of the list of recommended tracks. Default: 20. Minimum: 1. Maximum: 100.
+        /// For seeds with unusually small pools or when highly restrictive filtering is applied, it may be impossible to generate the requested number of recommended tracks.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.
+        /// Because min_*, max_* and target_* are applied to pools before relinking, the generated results may not precisely match the filters applied.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Recommendations> GetRecommendationsAsync(List<string> artistSeed = null, List<string> genreSeed = null, List<string> trackSeed = null,
+            TuneableTrack target = null, TuneableTrack min = null, TuneableTrack max = null, int limit = 20, string market = "")
+        {
+            return DownloadDataAsync<Recommendations>(_builder.GetRecommendations(artistSeed, genreSeed, trackSeed, target, min, max, limit, market));
+        }
+
+        /// <summary>
+        ///     Retrieve a list of available genres seed parameter values for recommendations.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public RecommendationSeedGenres GetRecommendationSeedsGenres()
+        {
+            return DownloadData<RecommendationSeedGenres>(_builder.GetRecommendationSeedsGenres());
+        }
+
+        /// <summary>
+        ///     Retrieve a list of available genres seed parameter values for recommendations asynchronously.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<RecommendationSeedGenres> GetRecommendationSeedsGenresAsync()
+        {
+            return DownloadDataAsync<RecommendationSeedGenres>(_builder.GetRecommendationSeedsGenres());
+        }
+
+        #endregion Browse
+
+        #region Follow
+
+        /// <summary>
+        ///     Get the current user’s followed artists.
+        /// </summary>
+        /// <param name="followType">The ID type: currently only artist is supported. </param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">The last artist ID retrieved from the previous request.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public FollowedArtists GetFollowedArtists(FollowType followType, int limit = 20, string after = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetFollowedArtists");
+            return DownloadData<FollowedArtists>(_builder.GetFollowedArtists(limit, after));
+        }
+
+        /// <summary>
+        ///     Get the current user’s followed artists asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: currently only artist is supported. </param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">The last artist ID retrieved from the previous request.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<FollowedArtists> GetFollowedArtistsAsync(FollowType followType, int limit = 20, string after = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetFollowedArtists");
+            return DownloadDataAsync<FollowedArtists>(_builder.GetFollowedArtists(limit, after));
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse Follow(FollowType followType, List<string> ids)
+        {
+            JObject ob = new JObject
+            {
+                {"ids", new JArray(ids)}
+            };
+            return UploadData<ErrorResponse>(_builder.Follow(followType), ob.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of one or more artists or other Spotify users asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> FollowAsync(FollowType followType, List<string> ids)
+        {
+            JObject ob = new JObject
+            {
+                {"ids", new JArray(ids)}
+            };
+            return (await UploadDataAsync<ErrorResponse>(_builder.Follow(followType),
+                    ob.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse Follow(FollowType followType, string id)
+        {
+            return Follow(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of one or more artists or other Spotify users asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> FollowAsync(FollowType followType, string id)
+        {
+            return FollowAsync(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse Unfollow(FollowType followType, List<string> ids)
+        {
+            JObject ob = new JObject
+            {
+                {"ids", new JArray(ids)}
+            };
+            return UploadData<ErrorResponse>(_builder.Unfollow(followType), ob.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of one or more artists or other Spotify users asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> UnfollowAsync(FollowType followType, List<string> ids)
+        {
+            JObject ob = new JObject
+            {
+                {"ids", new JArray(ids)}
+            };
+            return (await UploadDataAsync<ErrorResponse>(_builder.Unfollow(followType), ob.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse Unfollow(FollowType followType, string id)
+        {
+            return Unfollow(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of one or more artists or other Spotify users asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> UnfollowAsync(FollowType followType, string id)
+        {
+            return UnfollowAsync(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Check to see if the current user is following one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs to check</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> IsFollowing(FollowType followType, List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for IsFollowing");
+
+            var url = _builder.IsFollowing(followType, ids);
+            return DownloadList<bool>(url);
+        }
+
+
+
+        /// <summary>
+        ///     Check to see if the current user is following one or more artists or other Spotify users asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs to check</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for IsFollowing");
+
+            var url = _builder.IsFollowing(followType, ids);
+            return DownloadListAsync<bool>(url);
+        }
+
+        /// <summary>
+        ///     Check to see if the current user is following one artist or another Spotify user.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> IsFollowing(FollowType followType, string id)
+        {
+            return IsFollowing(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Check to see if the current user is following one artist or another Spotify user asynchronously.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="id">Artists or the Users Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> IsFollowingAsync(FollowType followType, string id)
+        {
+            return IsFollowingAsync(followType, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of a playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">
+        ///     The Spotify ID of the playlist. Any playlist can be followed, regardless of its public/private
+        ///     status, as long as you know its playlist ID.
+        /// </param>
+        /// <param name="showPublic">
+        ///     If true the playlist will be included in user's public playlists, if false it will remain
+        ///     private.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse FollowPlaylist(string ownerId, string playlistId, bool showPublic = true)
+        {
+            JObject body = new JObject
+            {
+                {"public", showPublic}
+            };
+            return UploadData<ErrorResponse>(_builder.FollowPlaylist(ownerId, playlistId, showPublic), body.ToString(Formatting.None), "PUT");
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of a playlist asynchronously.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">
+        ///     The Spotify ID of the playlist. Any playlist can be followed, regardless of its public/private
+        ///     status, as long as you know its playlist ID.
+        /// </param>
+        /// <param name="showPublic">
+        ///     If true the playlist will be included in user's public playlists, if false it will remain
+        ///     private.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> FollowPlaylistAsync(string ownerId, string playlistId, bool showPublic = true)
+        {
+            JObject body = new JObject
+            {
+                {"public", showPublic}
+            };
+            return UploadDataAsync<ErrorResponse>(_builder.FollowPlaylist(ownerId, playlistId, showPublic), body.ToString(Formatting.None), "PUT");
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of a playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist that is to be no longer followed.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse UnfollowPlaylist(string ownerId, string playlistId)
+        {
+            return UploadData<ErrorResponse>(_builder.UnfollowPlaylist(ownerId, playlistId), "", "DELETE");
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of a playlist asynchronously.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist that is to be no longer followed.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> UnfollowPlaylistAsync(string ownerId, string playlistId)
+        {
+            return UploadDataAsync<ErrorResponse>(_builder.UnfollowPlaylist(ownerId, playlistId), "", "DELETE");
+        }
+
+        /// <summary>
+        ///     Check to see if one or more Spotify users are following a specified playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist.</param>
+        /// <param name="ids">A list of Spotify User IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> IsFollowingPlaylist(string ownerId, string playlistId, List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for IsFollowingPlaylist");
+
+            var url = _builder.IsFollowingPlaylist(ownerId, playlistId, ids);
+            return DownloadList<bool>(url);
+        }
+
+        /// <summary>
+        ///     Check to see if one or more Spotify users are following a specified playlist asynchronously.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist.</param>
+        /// <param name="ids">A list of Spotify User IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for IsFollowingPlaylist");
+
+            var url = _builder.IsFollowingPlaylist(ownerId, playlistId, ids);
+            return DownloadListAsync<bool>(url);
+        }
+
+        /// <summary>
+        ///     Check to see if one or more Spotify users are following a specified playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist.</param>
+        /// <param name="id">A Spotify User ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> IsFollowingPlaylist(string ownerId, string playlistId, string id)
+        {
+            return IsFollowingPlaylist(ownerId, playlistId, new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Check to see if one or more Spotify users are following a specified playlist asynchronously.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist.</param>
+        /// <param name="id">A Spotify User ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> IsFollowingPlaylistAsync(string ownerId, string playlistId, string id)
+        {
+            return IsFollowingPlaylistAsync(ownerId, playlistId, new List<string> { id });
+        }
+
+        #endregion Follow
+
+        #region Library
+
+        /// <summary>
+        ///     Save one or more tracks to the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse SaveTracks(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return UploadData<ErrorResponse>(_builder.SaveTracks(), array.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Save one or more tracks to the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> SaveTracksAsync(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return (await UploadDataAsync<ErrorResponse>(_builder.SaveTracks(), array.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Save one track to the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="id">A Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse SaveTrack(string id)
+        {
+            return SaveTracks(new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Save one track to the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="id">A Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> SaveTrackAsync(string id)
+        {
+            return SaveTracksAsync(new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Get a list of the songs saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<SavedTrack> GetSavedTracks(int limit = 20, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetSavedTracks");
+            return DownloadData<Paging<SavedTrack>>(_builder.GetSavedTracks(limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get a list of the songs saved in the current Spotify user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<SavedTrack>> GetSavedTracksAsync(int limit = 20, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetSavedTracks");
+            return DownloadDataAsync<Paging<SavedTrack>>(_builder.GetSavedTracks(limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse RemoveSavedTracks(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return UploadData<ErrorResponse>(_builder.RemoveSavedTracks(), array.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> RemoveSavedTracksAsync(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return (await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedTracks(), array.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> CheckSavedTracks(List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for CheckSavedTracks");
+
+            var url = _builder.CheckSavedTracks(ids);
+            return DownloadList<bool>(url);
+        }
+
+        /// <summary>
+        ///     Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> CheckSavedTracksAsync(List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for CheckSavedTracks");
+            var url = _builder.CheckSavedTracks(ids);
+            return DownloadListAsync<bool>(url);
+        }
+
+        /// <summary>
+        ///     Save one or more albums to the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse SaveAlbums(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return UploadData<ErrorResponse>(_builder.SaveAlbums(), array.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Save one or more albums to the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> SaveAlbumsAsync(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return (await UploadDataAsync<ErrorResponse>(_builder.SaveAlbums(), array.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Save one album to the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="id">A Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse SaveAlbum(string id)
+        {
+            return SaveAlbums(new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Save one album to the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="id">A Spotify ID</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> SaveAlbumAsync(string id)
+        {
+            return SaveAlbumsAsync(new List<string> { id });
+        }
+
+        /// <summary>
+        ///     Get a list of the albums saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<SavedAlbum> GetSavedAlbums(int limit = 20, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetSavedAlbums");
+            return DownloadData<Paging<SavedAlbum>>(_builder.GetSavedAlbums(limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get a list of the albums saved in the current Spotify user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<SavedAlbum>> GetSavedAlbumsAsync(int limit = 20, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetSavedAlbumsAsync");
+            return DownloadDataAsync<Paging<SavedAlbum>>(_builder.GetSavedAlbums(limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Remove one or more albums from the current user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse RemoveSavedAlbums(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return UploadData<ErrorResponse>(_builder.RemoveSavedAlbums(), array.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove one or more albums from the current user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> RemoveSavedAlbumsAsync(List<string> ids)
+        {
+            JArray array = new JArray(ids);
+            return (await UploadDataAsync<ErrorResponse>(_builder.RemoveSavedAlbums(), array.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Check if one or more albums is already saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ListResponse<bool> CheckSavedAlbums(List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for CheckSavedTracks");
+
+            var url = _builder.CheckSavedAlbums(ids);
+            return DownloadList<bool>(url);
+        }
+
+        /// <summary>
+        ///     Check if one or more albums is already saved in the current Spotify user’s “Your Music” library asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ListResponse<bool>> CheckSavedAlbumsAsync(List<string> ids)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for CheckSavedAlbumsAsync");
+            var url = _builder.CheckSavedAlbums(ids);
+            return DownloadListAsync<bool>(url);
+        }
+
+        #endregion Library
+
+        #region Personalization
+
+        /// <summary>
+        ///     Get the current user’s top tracks based on calculated affinity.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<FullTrack> GetUsersTopTracks(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            return DownloadData<Paging<FullTrack>>(_builder.GetUsersTopTracks(timeRange, limit, offest));
+        }
+
+        /// <summary>
+        ///     Get the current user’s top tracks based on calculated affinity asynchronously.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<FullTrack>> GetUsersTopTracksAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            return DownloadDataAsync<Paging<FullTrack>>(_builder.GetUsersTopTracks(timeRange, limit, offest));
+        }
+
+        /// <summary>
+        ///     Get the current user’s top artists based on calculated affinity.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<FullArtist> GetUsersTopArtists(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            return DownloadData<Paging<FullArtist>>(_builder.GetUsersTopArtists(timeRange, limit, offest));
+        }
+
+        /// <summary>
+        ///     Get the current user’s top artists based on calculated affinity asynchronously.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<FullArtist>> GetUsersTopArtistsAsync(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            return DownloadDataAsync<Paging<FullArtist>>(_builder.GetUsersTopArtists(timeRange, limit, offest));
+        }
+
+        /// <summary>
+        ///     Get tracks from the current user’s recent play history.
+        /// </summary>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">A Unix timestamp in milliseconds. Returns all items after (but not including) this cursor position. If after is specified, before must not be specified.</param>
+        /// <param name="before">A Unix timestamp in milliseconds. Returns all items before (but not including) this cursor position. If before is specified, after must not be specified.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public CursorPaging<PlayHistory> GetUsersRecentlyPlayedTracks(int limit = 20, DateTime? after = null,
+            DateTime? before = null)
+        {
+            return DownloadData<CursorPaging<PlayHistory>>(_builder.GetUsersRecentlyPlayedTracks(limit, after, before));
+        }
+
+        /// <summary>
+        ///     Get tracks from the current user’s recent play history asynchronously
+        /// </summary>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">A Unix timestamp in milliseconds. Returns all items after (but not including) this cursor position. If after is specified, before must not be specified.</param>
+        /// <param name="before">A Unix timestamp in milliseconds. Returns all items before (but not including) this cursor position. If before is specified, after must not be specified.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<CursorPaging<PlayHistory>> GetUsersRecentlyPlayedTracksAsync(int limit = 20, DateTime? after = null,
+            DateTime? before = null)
+        {
+            return DownloadDataAsync<CursorPaging<PlayHistory>>(_builder.GetUsersRecentlyPlayedTracks(limit, after, before));
+        }
+
+        #endregion
+
+        #region Playlists
+
+        /// <summary>
+        ///     Get a list of the playlists owned or followed by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="limit">The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first playlist to return. Default: 0 (the first object)</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<SimplePlaylist> GetUserPlaylists(string userId, int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetUserPlaylists");
+            return DownloadData<Paging<SimplePlaylist>>(_builder.GetUserPlaylists(userId, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a list of the playlists owned or followed by a Spotify user asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="limit">The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first playlist to return. Default: 0 (the first object)</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<SimplePlaylist>> GetUserPlaylistsAsync(string userId, int limit = 20, int offset = 0)
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetUserPlaylists");
+            return DownloadDataAsync<Paging<SimplePlaylist>>(_builder.GetUserPlaylists(userId, limit, offset));
+        }
+
+        /// <summary>
+        ///     Get a playlist owned by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public FullPlaylist GetPlaylist(string userId, string playlistId, string fields = "", string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPlaylist");
+            return DownloadData<FullPlaylist>(_builder.GetPlaylist(userId, playlistId, fields, market));
+        }
+
+        /// <summary>
+        ///     Get a playlist owned by a Spotify user asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<FullPlaylist> GetPlaylistAsync(string userId, string playlistId, string fields = "", string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPlaylist");
+            return DownloadDataAsync<FullPlaylist>(_builder.GetPlaylist(userId, playlistId, fields, market));
+        }
+
+        /// <summary>
+        ///     Get full details of the tracks of a playlist owned by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="limit">The maximum number of tracks to return. Default: 100. Minimum: 1. Maximum: 100.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Paging<PlaylistTrack> GetPlaylistTracks(string userId, string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPlaylistTracks");
+            return DownloadData<Paging<PlaylistTrack>>(_builder.GetPlaylistTracks(userId, playlistId, fields, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Get full details of the tracks of a playlist owned by a Spotify user asyncronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="limit">The maximum number of tracks to return. Default: 100. Minimum: 1. Maximum: 100.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Paging<PlaylistTrack>> GetPlaylistTracksAsync(string userId, string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPlaylistTracks");
+            return DownloadDataAsync<Paging<PlaylistTrack>>(_builder.GetPlaylistTracks(userId, playlistId, fields, limit, offset, market));
+        }
+
+        /// <summary>
+        ///     Create a playlist for a Spotify user. (The playlist will be empty until you add tracks.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistName">
+        ///     The name for the new playlist, for example "Your Coolest Playlist". This name does not need
+        ///     to be unique.
+        /// </param>
+        /// <param name="isPublic">
+        ///     default true. If true the playlist will be public, if false it will be private. To be able to
+        ///     create private playlists, the user must have granted the playlist-modify-private scope.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public FullPlaylist CreatePlaylist(string userId, string playlistName, bool isPublic = true)
+        {
+            JObject body = new JObject
+            {
+                {"name", playlistName},
+                {"public", isPublic}
+            };
+            return UploadData<FullPlaylist>(_builder.CreatePlaylist(userId, playlistName, isPublic), body.ToString(Formatting.None));
+        }
+
+        /// <summary>
+        ///     Create a playlist for a Spotify user asynchronously. (The playlist will be empty until you add tracks.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistName">
+        ///     The name for the new playlist, for example "Your Coolest Playlist". This name does not need
+        ///     to be unique.
+        /// </param>
+        /// <param name="isPublic">
+        ///     default true. If true the playlist will be public, if false it will be private. To be able to
+        ///     create private playlists, the user must have granted the playlist-modify-private scope.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<FullPlaylist> CreatePlaylistAsync(string userId, string playlistName, bool isPublic = true)
+        {
+            JObject body = new JObject
+            {
+                {"name", playlistName},
+                {"public", isPublic}
+            };
+            return UploadDataAsync<FullPlaylist>(_builder.CreatePlaylist(userId, playlistName, isPublic), body.ToString(Formatting.None));
+        }
+
+        /// <summary>
+        ///     Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="newName">The new name for the playlist, for example "My New Playlist Title".</param>
+        /// <param name="newPublic">If true the playlist will be public, if false it will be private.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse UpdatePlaylist(string userId, string playlistId, string newName = null, bool? newPublic = null)
+        {
+            JObject body = new JObject();
+            if (newName != null)
+                body.Add("name", newName);
+            if (newPublic != null)
+                body.Add("public", newPublic);
+            return UploadData<ErrorResponse>(_builder.UpdatePlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Change a playlist’s name and public/private state asynchronously. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="newName">The new name for the playlist, for example "My New Playlist Title".</param>
+        /// <param name="newPublic">If true the playlist will be public, if false it will be private.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> UpdatePlaylistAsync(string userId, string playlistId, string newName = null, bool? newPublic = null)
+        {
+            JObject body = new JObject();
+            if (newName != null)
+                body.Add("name", newName);
+            if (newPublic != null)
+                body.Add("public", newPublic);
+            return (await UploadDataAsync<ErrorResponse>(_builder.UpdatePlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Replace all the tracks in a playlist, overwriting its existing tracks. This powerful request can be useful for
+        ///     replacing tracks, re-ordering existing tracks, or clearing the playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">A list of Spotify track URIs to set. A maximum of 100 tracks can be set in one request.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse ReplacePlaylistTracks(string userId, string playlistId, List<string> uris)
+        {
+            JObject body = new JObject
+            {
+                {"uris", new JArray(uris.Take(100))}
+            };
+            return UploadData<ErrorResponse>(_builder.ReplacePlaylistTracks(userId, playlistId), body.ToString(Formatting.None), "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Replace all the tracks in a playlist asynchronously, overwriting its existing tracks. This powerful request can be useful for
+        ///     replacing tracks, re-ordering existing tracks, or clearing the playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">A list of Spotify track URIs to set. A maximum of 100 tracks can be set in one request.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> ReplacePlaylistTracksAsync(string userId, string playlistId, List<string> uris)
+        {
+            JObject body = new JObject
+            {
+                {"uris", new JArray(uris.Take(100))}
+            };
+            return await (UploadDataAsync<ErrorResponse>(_builder.ReplacePlaylistTracks(userId, playlistId), body.ToString(Formatting.None), "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">
+        ///     array of objects containing Spotify URI strings (and their position in the playlist). A maximum of
+        ///     100 objects can be sent at once.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse RemovePlaylistTracks(string userId, string playlistId, List<DeleteTrackUri> uris)
+        {
+            JObject body = new JObject
+            {
+                {"tracks", JArray.FromObject(uris.Take(100))}
+            };
+            return UploadData<ErrorResponse>(_builder.RemovePlaylistTracks(userId, playlistId, uris), body.ToString(Formatting.None), "DELETE") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from a user’s playlist asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">
+        ///     array of objects containing Spotify URI strings (and their position in the playlist). A maximum of
+        ///     100 objects can be sent at once.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> RemovePlaylistTracksAsync(string userId, string playlistId, List<DeleteTrackUri> uris)
+        {
+            JObject body = new JObject
+            {
+                {"tracks", JArray.FromObject(uris.Take(100))}
+            };
+            return await (UploadDataAsync<ErrorResponse>(_builder.RemovePlaylistTracks(userId, playlistId, uris), body.ToString(Formatting.None), "DELETE").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uri">Spotify URI</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse RemovePlaylistTrack(string userId, string playlistId, DeleteTrackUri uri)
+        {
+            return RemovePlaylistTracks(userId, playlistId, new List<DeleteTrackUri> { uri });
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from a user’s playlist asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uri">Spotify URI</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> RemovePlaylistTrackAsync(string userId, string playlistId, DeleteTrackUri uri)
+        {
+            return RemovePlaylistTracksAsync(userId, playlistId, new List<DeleteTrackUri> { uri });
+        }
+
+        /// <summary>
+        ///     Add one or more tracks to a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">A list of Spotify track URIs to add</param>
+        /// <param name="position">The position to insert the tracks, a zero-based index</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse AddPlaylistTracks(string userId, string playlistId, List<string> uris, int? position = null)
+        {
+            JObject body = new JObject
+            {
+                {"uris", JArray.FromObject(uris.Take(100))}
+            };
+            return UploadData<ErrorResponse>(_builder.AddPlaylistTracks(userId, playlistId, uris, position), body.ToString(Formatting.None)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Add one or more tracks to a user’s playlist asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">A list of Spotify track URIs to add</param>
+        /// <param name="position">The position to insert the tracks, a zero-based index</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> AddPlaylistTracksAsync(string userId, string playlistId, List<string> uris, int? position = null)
+        {
+            JObject body = new JObject
+            {
+                {"uris", JArray.FromObject(uris.Take(100))}
+            };
+            return await (UploadDataAsync<ErrorResponse>(_builder.AddPlaylistTracks(userId, playlistId, uris, position), body.ToString(Formatting.None)).ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Add one or more tracks to a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uri">A Spotify Track URI</param>
+        /// <param name="position">The position to insert the tracks, a zero-based index</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse AddPlaylistTrack(string userId, string playlistId, string uri, int? position = null)
+        {
+            return AddPlaylistTracks(userId, playlistId, new List<string> { uri }, position);
+        }
+
+        /// <summary>
+        ///     Add one or more tracks to a user’s playlist asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uri">A Spotify Track URI</param>
+        /// <param name="position">The position to insert the tracks, a zero-based index</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<ErrorResponse> AddPlaylistTrackAsync(string userId, string playlistId, string uri, int? position = null)
+        {
+            return AddPlaylistTracksAsync(userId, playlistId, new List<string> { uri }, position);
+        }
+
+        /// <summary>
+        ///     Reorder a track or a group of tracks in a playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="rangeStart">The position of the first track to be reordered.</param>
+        /// <param name="insertBefore">The position where the tracks should be inserted. </param>
+        /// <param name="rangeLength">The amount of tracks to be reordered. Defaults to 1 if not set.</param>
+        /// <param name="snapshotId">The playlist's snapshot ID against which you want to make the changes.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Snapshot ReorderPlaylist(string userId, string playlistId, int rangeStart, int insertBefore, int rangeLength = 1, string snapshotId = "")
+        {
+            JObject body = new JObject
+            {
+                {"range_start", rangeStart},
+                {"range_length", rangeLength},
+                {"insert_before", insertBefore}
+            };
+            if (!string.IsNullOrEmpty(snapshotId))
+                body.Add("snapshot_id", snapshotId);
+            return UploadData<Snapshot>(_builder.ReorderPlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT");
+        }
+
+        /// <summary>
+        ///     Reorder a track or a group of tracks in a playlist asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="rangeStart">The position of the first track to be reordered.</param>
+        /// <param name="insertBefore">The position where the tracks should be inserted. </param>
+        /// <param name="rangeLength">The amount of tracks to be reordered. Defaults to 1 if not set.</param>
+        /// <param name="snapshotId">The playlist's snapshot ID against which you want to make the changes.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<Snapshot> ReorderPlaylistAsync(string userId, string playlistId, int rangeStart, int insertBefore, int rangeLength = 1, string snapshotId = "")
+        {
+            JObject body = new JObject
+            {
+                {"range_start", rangeStart},
+                {"range_length", rangeLength},
+                {"insert_before", insertBefore},
+                {"snapshot_id", snapshotId}
+            };
+            if (!string.IsNullOrEmpty(snapshotId))
+                body.Add("snapshot_id", snapshotId);
+            return UploadDataAsync<Snapshot>(_builder.ReorderPlaylist(userId, playlistId), body.ToString(Formatting.None), "PUT");
+        }
+
+        #endregion Playlists
+
+        #region Profiles
+
+        /// <summary>
+        ///     Get detailed profile information about the current user (including the current user’s username).
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public PrivateProfile GetPrivateProfile()
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPrivateProfile");
+            return DownloadData<PrivateProfile>(_builder.GetPrivateProfile());
+        }
+
+        /// <summary>
+        ///     Get detailed profile information about the current user asynchronously (including the current user’s username).
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<PrivateProfile> GetPrivateProfileAsync()
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for GetPrivateProfile");
+            return DownloadDataAsync<PrivateProfile>(_builder.GetPrivateProfile());
+        }
+
+        /// <summary>
+        ///     Get public profile information about a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <returns></returns>
+        public PublicProfile GetPublicProfile(string userId)
+        {
+            return DownloadData<PublicProfile>(_builder.GetPublicProfile(userId));
+        }
+
+        /// <summary>
+        ///     Get public profile information about a Spotify user asynchronously.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <returns></returns>
+        public Task<PublicProfile> GetPublicProfileAsync(string userId)
+        {
+            return DownloadDataAsync<PublicProfile>(_builder.GetPublicProfile(userId));
+        }
+
+        #endregion Profiles
+
+        #region Tracks
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple tracks based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public SeveralTracks GetSeveralTracks(List<string> ids, string market = "")
+        {
+            return DownloadData<SeveralTracks>(_builder.GetSeveralTracks(ids, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple tracks based on their Spotify IDs asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Task<SeveralTracks> GetSeveralTracksAsync(List<string> ids, string market = "")
+        {
+            return DownloadDataAsync<SeveralTracks>(_builder.GetSeveralTracks(ids, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public FullTrack GetTrack(string id, string market = "")
+        {
+            return DownloadData<FullTrack>(_builder.GetTrack(id, market));
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single track identified by its unique Spotify ID asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public Task<FullTrack> GetTrackAsync(string id, string market = "")
+        {
+            return DownloadDataAsync<FullTrack>(_builder.GetTrack(id, market));
+        }
+
+        /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public AudioAnalysis GetAudioAnalysis(string id)
+        {
+            return DownloadData<AudioAnalysis>(_builder.GetAudioAnalysis(id));
+        }
+
+        /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<AudioAnalysis> GetAudioAnalysisAsync(string id)
+        {
+            return DownloadDataAsync<AudioAnalysis>(_builder.GetAudioAnalysis(id));
+        }
+
+        /// <summary>
+        ///     Get audio feature information for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public AudioFeatures GetAudioFeatures(string id)
+        {
+            return DownloadData<AudioFeatures>(_builder.GetAudioFeatures(id));
+        }
+
+        /// <summary>
+        ///     Get audio feature information for a single track identified by its unique Spotify ID asynchronously.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<AudioFeatures> GetAudioFeaturesAsync(string id)
+        {
+            return DownloadDataAsync<AudioFeatures>(_builder.GetAudioFeatures(id));
+        }
+
+        /// <summary>
+        ///     Get audio features for multiple tracks based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of Spotify Track-IDs. Maximum: 100 IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public SeveralAudioFeatures GetSeveralAudioFeatures(List<string> ids)
+        {
+            return DownloadData<SeveralAudioFeatures>(_builder.GetSeveralAudioFeatures(ids));
+        }
+
+        /// <summary>
+        ///     Get audio features for multiple tracks based on their Spotify IDs asynchronously.
+        /// </summary>
+        /// <param name="ids">A list of Spotify Track-IDs. Maximum: 100 IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public Task<SeveralAudioFeatures> GetSeveralAudioFeaturesAsync(List<string> ids)
+        {
+            return DownloadDataAsync<SeveralAudioFeatures>(_builder.GetSeveralAudioFeatures(ids));
+        }
+
+        #endregion Tracks
+
+        #region Player
+
+        /// <summary>
+        ///     Get information about a user’s available devices.
+        /// </summary>
+        /// <returns></returns>
+        public AvailabeDevices GetDevices()
+        {
+            return DownloadData<AvailabeDevices>(_builder.GetDevices());
+        }
+
+        /// <summary>
+        ///     Get information about the user’s current playback state, including track, track progress, and active device.
+        /// </summary>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public PlaybackContext GetPlayback(string market = "")
+        {
+            return DownloadData<PlaybackContext>(_builder.GetPlayback(market));
+        }
+
+        /// <summary>
+        ///     Get the object currently being played on the user’s Spotify account.
+        /// </summary>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public PlaybackContext GetPlayingTrack(string market = "")
+        {
+            return DownloadData<PlaybackContext>(_builder.GetPlayingTrack(market));
+        }
+
+        /// <summary>
+        ///     Transfer playback to a new device and determine if it should start playing.
+        /// </summary>
+        /// <param name="deviceId">ID of the device on which playback should be started/transferred to</param>
+        /// <param name="play">
+        /// true: ensure playback happens on new device.
+        /// false or not provided: keep the current playback state.
+        /// </param>
+        /// <returns></returns>
+        public ErrorResponse TransferPlayback(string deviceId, bool play = false) => TransferPlayback(
+            new List<string> { deviceId }, play);
+
+        /// <summary>
+        ///     Transfer playback to a new device and determine if it should start playing. 
+        ///     NOTE: Although an array is accepted, only a single device_id is currently supported. Supplying more than one will return 400 Bad Request
+        /// </summary>
+        /// <param name="deviceIds">A array containing the ID of the device on which playback should be started/transferred.</param>
+        /// <param name="play">
+        /// true: ensure playback happens on new device.
+        /// false or not provided: keep the current playback state.
+        /// </param>
+        /// <returns></returns>
+        public ErrorResponse TransferPlayback(List<string> deviceIds, bool play = false)
+        {
+            JObject ob = new JObject()
+            {
+                { "play", play },
+                { "device_ids", new JArray(deviceIds) }
+            };
+            return UploadData<ErrorResponse>(_builder.TransferPlayback(), ob.ToString(Formatting.None), "PUT");
+        }
+
+        /// <summary>
+        ///     Start a new context or resume current playback on the user’s active device.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <param name="contextUri">Spotify URI of the context to play.</param>
+        /// <param name="uris">A JSON array of the Spotify track URIs to play.</param>
+        /// <param name="offset">Indicates from where in the context playback should start. 
+        /// Only available when context_uri corresponds to an album or playlist object, or when the uris parameter is used.</param>
+        /// <returns></returns>
+        public ErrorResponse ResumePlayback(string deviceId = "", string contextUri = "", List<string> uris = null,
+            int? offset = null)
+        {
+            JObject ob = new JObject();
+            if(!string.IsNullOrEmpty(contextUri))
+                ob.Add("context_uri", contextUri);
+            if(uris != null)
+                ob.Add("uris", new JArray(uris));
+            if(offset != null)
+                ob.Add("offset", offset);
+            return UploadData<ErrorResponse>(_builder.ResumePlayback(deviceId), ob.ToString(Formatting.None), "PUT");
+        }
+
+        /// <summary>
+        ///     Pause playback on the user’s account.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse PausePlayback(string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.PausePlayback(deviceId), string.Empty, "PUT");
+        }
+
+        /// <summary>
+        ///     Skips to next track in the user’s queue.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SkipPlaybackToNext(string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SkipPlaybackToNext(deviceId), string.Empty);
+        }
+
+        /// <summary>
+        ///     Skips to previous track in the user’s queue.
+        ///     Note that this will ALWAYS skip to the previous track, regardless of the current track’s progress.
+        ///     Returning to the start of the current track should be performed using the https://api.spotify.com/v1/me/player/seek endpoint.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SkipPlaybackToPrevious(string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SkipPlaybackToPrevious(deviceId), string.Empty);
+        }
+
+        /// <summary>
+        ///     Seeks to the given position in the user’s currently playing track.
+        /// </summary>
+        /// <param name="positionMs">The position in milliseconds to seek to. Must be a positive number. 
+        /// Passing in a position that is greater than the length of the track will cause the player to start playing the next song.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SeekPlayback(int positionMs, string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SeekPlayback(positionMs, deviceId), string.Empty, "PUT");
+        }
+
+        /// <summary>
+        ///     Set the repeat mode for the user’s playback. Options are repeat-track, repeat-context, and off.
+        /// </summary>
+        /// <param name="state">track, context or off. </param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SetRepeatMode(RepeatState state, string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SetRepeatMode(state, deviceId), string.Empty, "PUT");
+        }
+
+        /// <summary>
+        ///     Set the volume for the user’s current playback device.
+        /// </summary>
+        /// <param name="volumePercent">Integer. The volume to set. Must be a value from 0 to 100 inclusive.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SetVolume(int volumePercent, string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SetVolume(volumePercent, deviceId), string.Empty, "PUT");
+        }
+
+        /// <summary>
+        ///     Toggle shuffle on or off for user’s playback.
+        /// </summary>
+        /// <param name="shuffle">True or False</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public ErrorResponse SetShuffle(bool shuffle, string deviceId = "")
+        {
+            return UploadData<ErrorResponse>(_builder.SetShuffle(shuffle, deviceId), string.Empty, "PUT");
+        }
+
+        #endregion
+
+        #region Util
+
+        public TOut GetNextPage<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        {
+            if (!paging.HasNextPage())
+                throw new InvalidOperationException("This Paging-Object has no Next-Page");
+            return DownloadData<TOut>(paging.Next);
+        }
+
+        public Paging<T> GetNextPage<T>(Paging<T> paging)
+        {
+            return GetNextPage<Paging<T>, T>(paging);
+        }
+
+        public Task<TOut> GetNextPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        {
+            if (!paging.HasNextPage())
+                throw new InvalidOperationException("This Paging-Object has no Next-Page");
+            return DownloadDataAsync<TOut>(paging.Next);
+        }
+
+        public Task<Paging<T>> GetNextPageAsync<T>(Paging<T> paging)
+        {
+            return GetNextPageAsync<Paging<T>, T>(paging);
+        }
+
+        public TOut GetPreviousPage<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        {
+            if (!paging.HasPreviousPage())
+                throw new InvalidOperationException("This Paging-Object has no Previous-Page");
+            return DownloadData<TOut>(paging.Previous);
+        }
+
+        public Paging<T> GetPreviousPage<T>(Paging<T> paging)
+        {
+            return GetPreviousPage<Paging<T>, T>(paging);
+        }
+
+        public Task<TOut> GetPreviousPageAsync<TOut, TIn>(Paging<TIn> paging) where TOut : BasicModel
+        {
+            if (!paging.HasPreviousPage())
+                throw new InvalidOperationException("This Paging-Object has no Previous-Page");
+            return DownloadDataAsync<TOut>(paging.Previous);
+        }
+
+        public Task<Paging<T>> GetPreviousPageAsync<T>(Paging<T> paging)
+        {
+            return GetPreviousPageAsync<Paging<T>, T>(paging);
+        }
+
+        private ListResponse<T> DownloadList<T>(string url)
+        {
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            ListResponse<T> data = null;
+            do
+            {
+                if (data != null) { Thread.Sleep(RetryAfter); }
+                Tuple<ResponseInfo, JToken> res = DownloadDataAlt<JToken>(url);
+                data = ExtractDataToListResponse<T>(res);
+
+                lastError = data.Error;
+
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+            return data;
+        }
+
+        private async Task<ListResponse<T>> DownloadListAsync<T>(string url)
+        {
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            ListResponse<T> data = null;
+            do
+            {
+                if (data != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                Tuple<ResponseInfo, JToken> res = await DownloadDataAltAsync<JToken>(url).ConfigureAwait(false);
+                data = ExtractDataToListResponse<T>(res);
+
+                lastError = data.Error;
+
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+            return data;
+        }
+
+        private static ListResponse<T> ExtractDataToListResponse<T>(Tuple<ResponseInfo, JToken> res)
+        {
+            ListResponse<T> ret;
+            if (res.Item2 is JArray)
+            {
+                ret = new ListResponse<T>
+                {
+                    List = res.Item2.ToObject<List<T>>(),
+                    Error = null
+                };
+            }
+            else
+            { 
+                ret = new ListResponse<T>
+                {
+                    List = null,
+                    Error = res.Item2["error"].ToObject<Error>()
+                };
+            }
+            ret.AddResponseInfo(res.Item1);
+            return ret;
+        }
+
+        public T UploadData<T>(string url, string uploadData, string method = "POST") where T : BasicModel
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for all Upload-Actions");
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            Tuple<ResponseInfo, T> response = null;
+            do
+            {
+                Dictionary<string, string> headers = new Dictionary<string, string>
+                {
+                    { "Authorization", TokenType + " " + AccessToken},
+                    { "Content-Type", "application/json" }
+                };
+
+                if (response != null) { Thread.Sleep(RetryAfter); }
+                response = WebClient.UploadJson<T>(url, uploadData, method, headers);
+
+                response.Item2.AddResponseInfo(response.Item1);
+                lastError = response.Item2.Error;
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+            return response.Item2;
+        }
+
+        public async Task<T> UploadDataAsync<T>(string url, string uploadData, string method = "POST") where T : BasicModel
+        {
+            if (!UseAuth)
+                throw new InvalidOperationException("Auth is required for all Upload-Actions");
+
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            Tuple<ResponseInfo, T> response = null;
+            do
+            {
+                Dictionary<string, string> headers = new Dictionary<string, string>
+                {
+                    { "Authorization", TokenType + " " + AccessToken},
+                    { "Content-Type", "application/json" }
+                };
+
+                if (response != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                response = await WebClient.UploadJsonAsync<T>(url, uploadData, method, headers).ConfigureAwait(false);
+
+                response.Item2.AddResponseInfo(response.Item1);
+                lastError = response.Item2.Error;
+
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+            return response.Item2;
+        }
+
+        public T DownloadData<T>(string url) where T : BasicModel
+        {
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            Tuple<ResponseInfo, T> response = null;
+            do
+            {
+                if(response != null) { Thread.Sleep(RetryAfter); }
+                response = DownloadDataAlt<T>(url);
+
+                response.Item2.AddResponseInfo(response.Item1);
+                lastError = response.Item2.Error;
+
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+
+            return response.Item2;
+        }
+
+        public async Task<T> DownloadDataAsync<T>(string url) where T : BasicModel
+        {
+            int triesLeft = RetryTimes + 1;
+            Error lastError;
+
+            Tuple<ResponseInfo, T> response = null;
+            do
+            {
+                if (response != null) { await Task.Delay(RetryAfter).ConfigureAwait(false); }
+                response = await DownloadDataAltAsync<T>(url).ConfigureAwait(false);
+
+                response.Item2.AddResponseInfo(response.Item1);
+                lastError = response.Item2.Error;
+
+                triesLeft -= 1;
+
+            } while (UseAutoRetry && triesLeft > 0 && lastError != null && RetryErrorCodes.Contains(lastError.Status));
+
+
+            return response.Item2;
+        }
+
+        private Tuple<ResponseInfo, T> DownloadDataAlt<T>(string url)
+        {
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            if (UseAuth)
+                headers.Add("Authorization", TokenType + " " + AccessToken);
+            return WebClient.DownloadJson<T>(url, headers);
+        }
+
+        private Task<Tuple<ResponseInfo, T>> DownloadDataAltAsync<T>(string url)
+        {
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            if (UseAuth)
+                headers.Add("Authorization", TokenType + " " + AccessToken);
+            return WebClient.DownloadJsonAsync<T>(url, headers);
+        }
+
+        #endregion Util
+    }
+}

--- a/SpotifyAPI.Core/Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI.Core/Web/SpotifyWebBuilder.cs
@@ -1,0 +1,1003 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+
+namespace SpotifyAPI.Web
+{
+    /// <summary>
+    /// SpotifyAPI URL-Generator
+    /// </summary>
+    public class SpotifyWebBuilder
+    {
+        public const string APIBase = "https://api.spotify.com/v1";
+
+        #region Search
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists, albums, tracks or playlists that match a keyword string.
+        /// </summary>
+        /// <param name="q">The search query's keywords (and optional field filters and operators), for example q=roadhouse+blues.</param>
+        /// <param name="type">A list of item types to search across.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first result to return. Default: 0</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code or the string from_token.</param>
+        /// <returns></returns>
+        public string SearchItems(string q, SearchType type, int limit = 20, int offset = 0, string market = "")
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder(APIBase + "/search");
+            builder.Append("?q=" + q);
+            builder.Append("&type=" + type.GetStringAttribute(","));
+            builder.Append("&limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        #endregion Search
+
+        #region Albums
+
+        /// <summary>
+        ///     Get Spotify catalog information about an album’s tracks. Optional parameters can be used to limit the number of
+        ///     tracks returned.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first track to return. Default: 0 (the first object).</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetAlbumTracks(string id, int limit = 20, int offset = 0, string market = "")
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/albums/" + id + "/tracks");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single album.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the album.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetAlbum(string id, string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/albums/{id}";
+            return $"{APIBase}/albums/{id}?market={market}";
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple albums identified by their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the albums. Maximum: 20 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetSeveralAlbums(List<string> ids, string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/albums?ids={string.Join(",", ids.Take(20))}";
+            return $"{APIBase}/albums?market={market}&ids={string.Join(",", ids.Take(20))}";
+        }
+
+        #endregion Albums
+
+        #region Artists
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single artist identified by their unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public string GetArtist(string id)
+        {
+            return $"{APIBase}/artists/{id}";
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about artists similar to a given artist. Similarity is based on analysis of the
+        ///     Spotify community’s listening history.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <returns></returns>
+        public string GetRelatedArtists(string id)
+        {
+            return $"{APIBase}/artists/{id}/related-artists";
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s top tracks by country.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="country">The country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <returns></returns>
+        public string GetArtistsTopTracks(string id, string country)
+        {
+            return $"{APIBase}/artists/{id}/top-tracks?country={country}";
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information about an artist’s albums. Optional parameters can be specified in the query string
+        ///     to filter and sort the response.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the artist.</param>
+        /// <param name="type">
+        ///     A list of keywords that will be used to filter the response. If not supplied, all album types will
+        ///     be returned
+        /// </param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first album to return. Default: 0</param>
+        /// <param name="market">
+        ///     An ISO 3166-1 alpha-2 country code. Supply this parameter to limit the response to one particular
+        ///     geographical market
+        /// </param>
+        /// <returns></returns>
+        public string GetArtistsAlbums(string id, AlbumType type = AlbumType.All, int limit = 20, int offset = 0, string market = "")
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/artists/" + id + "/albums");
+            builder.Append("?album_type=" + type.GetStringAttribute(","));
+            builder.Append("&limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for several artists based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the artists. Maximum: 50 IDs.</param>
+        /// <returns></returns>
+        public string GetSeveralArtists(List<string> ids)
+        {
+            return $"{APIBase}/artists?ids={string.Join(",", ids.Take(50))}";
+        }
+
+        #endregion Artists
+
+        #region Browse
+
+        /// <summary>
+        ///     Get a list of Spotify featured playlists (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="locale">
+        ///     The desired language, consisting of a lowercase ISO 639 language code and an uppercase ISO 3166-1
+        ///     alpha-2 country code, joined by an underscore.
+        /// </param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="timestamp">A timestamp in ISO 8601 format</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetFeaturedPlaylists(string locale = "", string country = "", DateTime timestamp = default(DateTime), int limit = 20, int offset = 0)
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/browse/featured-playlists");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(locale))
+                builder.Append("&locale=" + locale);
+            if (!string.IsNullOrEmpty(country))
+                builder.Append("&country=" + country);
+            if (timestamp != default(DateTime))
+                builder.Append("&timestamp=" + timestamp.ToString("yyyy-MM-ddTHH:mm:ss"));
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetNewAlbumReleases(string country = "", int limit = 20, int offset = 0)
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/browse/new-releases");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(country))
+                builder.Append("&country=" + country);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter if you want to narrow the
+        ///     list of returned categories to those relevant to a particular country
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <param name="limit">The maximum number of categories to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first item to return. Default: 0 (the first object).</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetCategories(string country = "", string locale = "", int limit = 20, int offset = 0)
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder(APIBase + "/browse/categories");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(country))
+                builder.Append("&country=" + country);
+            if (!string.IsNullOrEmpty(locale))
+                builder.Append("&locale=" + locale);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">
+        ///     A country: an ISO 3166-1 alpha-2 country code. Provide this parameter to ensure that the category
+        ///     exists for a particular country.
+        /// </param>
+        /// <param name="locale">
+        ///     The desired language, consisting of an ISO 639 language code and an ISO 3166-1 alpha-2 country
+        ///     code, joined by an underscore
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetCategory(string categoryId, string country = "", string locale = "")
+        {
+            StringBuilder builder = new StringBuilder(APIBase + "/browse/categories/" + categoryId);
+            if (!string.IsNullOrEmpty(country))
+                builder.Append("?country=" + country);
+            if (!string.IsNullOrEmpty(locale))
+                builder.Append((country == "" ? "?locale=" : "&locale=") + locale);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get a list of Spotify playlists tagged with a particular category.
+        /// </summary>
+        /// <param name="categoryId">The Spotify category ID for the category.</param>
+        /// <param name="country">A country: an ISO 3166-1 alpha-2 country code.</param>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first item to return. Default: 0</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetCategoryPlaylists(string categoryId, string country = "", int limit = 20, int offset = 0)
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder(APIBase + "/browse/categories/" + categoryId + "/playlists");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(country))
+                builder.Append("&country=" + country);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Create a playlist-style listening experience based on seed artists, tracks and genres.
+        /// </summary>
+        /// <param name="artistSeed">A comma separated list of Spotify IDs for seed artists. 
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="genreSeed">A comma separated list of any genres in the set of available genre seeds.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="trackSeed">A comma separated list of Spotify IDs for a seed track.
+        /// Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres.
+        /// </param>
+        /// <param name="target">Tracks with the attribute values nearest to the target values will be preferred.</param>
+        /// <param name="min">For each tunable track attribute, a hard floor on the selected track attribute’s value can be provided</param>
+        /// <param name="max">For each tunable track attribute, a hard ceiling on the selected track attribute’s value can be provided</param>
+        /// <param name="limit">The target size of the list of recommended tracks. Default: 20. Minimum: 1. Maximum: 100.
+        /// For seeds with unusually small pools or when highly restrictive filtering is applied, it may be impossible to generate the requested number of recommended tracks.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.
+        /// Because min_*, max_* and target_* are applied to pools before relinking, the generated results may not precisely match the filters applied.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetRecommendations(List<string> artistSeed = null, List<string> genreSeed = null, List<string> trackSeed = null,
+            TuneableTrack target = null, TuneableTrack min = null, TuneableTrack max = null, int limit = 20, string market = "")
+        {
+            limit = Math.Min(100, limit);
+            StringBuilder builder = new StringBuilder($"{APIBase}/recommendations");
+            builder.Append("?limit=" + limit);
+            if (artistSeed?.Count > 0)
+                builder.Append("&seed_artists=" + string.Join(",", artistSeed));
+            if (genreSeed?.Count > 0)
+                builder.Append("&seed_genres=" + string.Join(",", genreSeed));
+            if (trackSeed?.Count > 0)
+                builder.Append("&seed_tracks=" + string.Join(",", trackSeed));
+            if (target != null)
+                builder.Append(target.BuildUrlParams("target"));
+            if (min != null)
+                builder.Append(min.BuildUrlParams("min"));
+            if (max != null)
+                builder.Append(max.BuildUrlParams("max"));
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Retrieve a list of available genres seed parameter values for recommendations.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetRecommendationSeedsGenres()
+        {
+            return $"{APIBase}/recommendations/available-genre-seeds";
+        }
+
+        #endregion Browse
+
+        #region Follow
+
+        /// <summary>
+        ///     Get the current user’s followed artists.
+        /// </summary>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">The last artist ID retrieved from the previous request.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetFollowedArtists(int limit = 20, string after = "")
+        {
+            limit = Math.Min(limit, 50);
+            const FollowType followType = FollowType.Artist; //currently only artist is supported.
+            StringBuilder builder = new StringBuilder(APIBase + "/me/following?type=" + followType.GetStringAttribute());
+            builder.Append("&limit=" + limit);
+            if (!string.IsNullOrEmpty(after))
+                builder.Append("&after=" + after);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string Follow(FollowType followType)
+        {
+            return $"{APIBase}/me/following?type={followType.GetStringAttribute()}";
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string Unfollow(FollowType followType)
+        {
+            return $"{APIBase}/me/following?type={followType.GetStringAttribute()}";
+        }
+
+        /// <summary>
+        ///     Check to see if the current user is following one or more artists or other Spotify users.
+        /// </summary>
+        /// <param name="followType">The ID type: either artist or user.</param>
+        /// <param name="ids">A list of the artist or the user Spotify IDs to check</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string IsFollowing(FollowType followType, List<string> ids)
+        {
+            return $"{APIBase}/me/following/contains?type={followType.GetStringAttribute()}&ids={string.Join(",", ids)}";
+        }
+
+        /// <summary>
+        ///     Add the current user as a follower of a playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">
+        ///     The Spotify ID of the playlist. Any playlist can be followed, regardless of its public/private
+        ///     status, as long as you know its playlist ID.
+        /// </param>
+        /// <param name="showPublic">
+        ///     If true the playlist will be included in user's public playlists, if false it will remain
+        ///     private.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string FollowPlaylist(string ownerId, string playlistId, bool showPublic = true)
+        {
+            return $"{APIBase}/users/{ownerId}/playlists/{playlistId}/followers";
+        }
+
+        /// <summary>
+        ///     Remove the current user as a follower of a playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist that is to be no longer followed.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string UnfollowPlaylist(string ownerId, string playlistId)
+        {
+            return $"{APIBase}/users/{ownerId}/playlists/{playlistId}/followers";
+        }
+
+        /// <summary>
+        ///     Check to see if one or more Spotify users are following a specified playlist.
+        /// </summary>
+        /// <param name="ownerId">The Spotify user ID of the person who owns the playlist.</param>
+        /// <param name="playlistId">The Spotify ID of the playlist.</param>
+        /// <param name="ids">A list of Spotify User IDs</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string IsFollowingPlaylist(string ownerId, string playlistId, List<string> ids)
+        {
+            return $"{APIBase}/users/{ownerId}/playlists/{playlistId}/followers/contains?ids={string.Join(",", ids)}";
+        }
+
+        #endregion Follow
+
+        #region Library
+
+        /// <summary>
+        ///     Save one or more tracks to the current user’s “Your Music” library.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string SaveTracks()
+        {
+            return APIBase + "/me/tracks/";
+        }
+
+        /// <summary>
+        ///     Get a list of the songs saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetSavedTracks(int limit = 20, int offset = 0, string market = "")
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/me/tracks");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from the current user’s “Your Music” library.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string RemoveSavedTracks()
+        {
+            return APIBase + "/me/tracks/";
+        }
+
+        /// <summary>
+        ///     Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string CheckSavedTracks(List<string> ids)
+        {
+            return APIBase + "/me/tracks/contains?ids=" + string.Join(",", ids);
+        }
+
+        /// <summary>
+        ///     Save one or more albums to the current user’s "Your Music" library.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string SaveAlbums()
+        {
+            return $"{APIBase}/me/albums";
+        }
+
+        /// <summary>
+        ///     Get a list of the albums saved in the current Spotify user’s "Your Music" library.
+        /// </summary>
+        /// <param name="limit">The maximum number of objects to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetSavedAlbums(int limit = 20, int offset = 0, string market = "")
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/me/albums");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Remove one or more albums from the current user’s "Your Music" library.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string RemoveSavedAlbums()
+        {
+            return APIBase + "/me/albums/";
+        }
+
+        /// <summary>
+        ///     Check if one or more albums is already saved in the current Spotify user’s "Your Music" library.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string CheckSavedAlbums(List<string> ids)
+        {
+            return APIBase + "/me/albums/contains?ids=" + string.Join(",", ids);
+        }
+
+        #endregion Library
+
+        #region Personalization
+
+        /// <summary>
+        ///     Get the current user’s top tracks based on calculated affinity.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetUsersTopTracks(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder($"{APIBase}/me/top/tracks");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offest);
+            builder.Append("&time_range=" + timeRange.GetStringAttribute());
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get the current user’s top artists based on calculated affinity.
+        /// </summary>
+        /// <param name="timeRange">Over what time frame the affinities are computed. 
+        /// Valid values: long_term (calculated from several years of data and including all new data as it becomes available), 
+        /// medium_term (approximately last 6 months), short_term (approximately last 4 weeks). </param>
+        /// <param name="limit">The number of entities to return. Default: 20. Minimum: 1. Maximum: 50</param>
+        /// <param name="offest">The index of the first entity to return. Default: 0 (i.e., the first track). Use with limit to get the next set of entities.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetUsersTopArtists(TimeRangeType timeRange = TimeRangeType.MediumTerm, int limit = 20, int offest = 0)
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder($"{APIBase}/me/top/artists");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offest);
+            builder.Append("&time_range=" + timeRange.GetStringAttribute());
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get tracks from the current user’s recent play history.
+        /// </summary>
+        /// <param name="limit">The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="after">A Unix timestamp in milliseconds. Returns all items after (but not including) this cursor position. If after is specified, before must not be specified.</param>
+        /// <param name="before">A Unix timestamp in milliseconds. Returns all items before (but not including) this cursor position. If before is specified, after must not be specified.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetUsersRecentlyPlayedTracks(int limit = 20, DateTime? after = null, DateTime? before = null)
+        {
+            limit = Math.Min(50, limit);
+            StringBuilder builder = new StringBuilder($"{APIBase}/me/player/recently-played");
+            builder.Append("?limit=" + limit);
+            if (after.HasValue)
+                builder.Append("&after=" + after.Value.ToUnixTimeMillisecondsPoly());
+            if (before.HasValue)
+                builder.Append("&before=" + before.Value.ToUnixTimeMillisecondsPoly());
+            return builder.ToString();
+        }
+
+        #endregion
+
+        #region Playlists
+
+        /// <summary>
+        ///     Get a list of the playlists owned or followed by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="limit">The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50. </param>
+        /// <param name="offset">The index of the first playlist to return. Default: 0 (the first object)</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetUserPlaylists(string userId, int limit = 20, int offset = 0)
+        {
+            limit = Math.Min(limit, 50);
+            StringBuilder builder = new StringBuilder(APIBase + "/users/" + userId + "/playlists");
+            builder.Append("?limit=" + limit);
+            builder.Append("&offset=" + offset);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get a playlist owned by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetPlaylist(string userId, string playlistId, string fields = "", string market = "")
+        {
+            StringBuilder builder = new StringBuilder(APIBase + "/users/" + userId + "/playlists/" + playlistId);
+            builder.Append("?fields=" + fields);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Get full details of the tracks of a playlist owned by a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="fields">
+        ///     Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are
+        ///     returned.
+        /// </param>
+        /// <param name="limit">The maximum number of tracks to return. Default: 100. Minimum: 1. Maximum: 100.</param>
+        /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetPlaylistTracks(string userId, string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
+        {
+            limit = Math.Min(limit, 100);
+            StringBuilder builder = new StringBuilder(APIBase + "/users/" + userId + "/playlists/" + playlistId + "/tracks");
+            builder.Append("?fields=" + fields);
+            builder.Append("&limit=" + limit);
+            builder.Append("&offset=" + offset);
+            if (!string.IsNullOrEmpty(market))
+                builder.Append("&market=" + market);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Create a playlist for a Spotify user. (The playlist will be empty until you add tracks.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistName">
+        ///     The name for the new playlist, for example "Your Coolest Playlist". This name does not need
+        ///     to be unique.
+        /// </param>
+        /// <param name="isPublic">
+        ///     default true. If true the playlist will be public, if false it will be private. To be able to
+        ///     create private playlists, the user must have granted the playlist-modify-private scope.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string CreatePlaylist(string userId, string playlistName, Boolean isPublic = true)
+        {
+            return $"{APIBase}/users/{userId}/playlists";
+        }
+
+        /// <summary>
+        ///     Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string UpdatePlaylist(string userId, string playlistId)
+        {
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}";
+        }
+
+        /// <summary>
+        ///     Replace all the tracks in a playlist, overwriting its existing tracks. This powerful request can be useful for
+        ///     replacing tracks, re-ordering existing tracks, or clearing the playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string ReplacePlaylistTracks(string userId, string playlistId)
+        {
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks";
+        }
+
+        /// <summary>
+        ///     Remove one or more tracks from a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">
+        ///     array of objects containing Spotify URI strings (and their position in the playlist). A maximum of
+        ///     100 objects can be sent at once.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string RemovePlaylistTracks(string userId, string playlistId, List<DeleteTrackUri> uris)
+        {
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks";
+        }
+
+        /// <summary>
+        ///     Add one or more tracks to a user’s playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="uris">A list of Spotify track URIs to add</param>
+        /// <param name="position">The position to insert the tracks, a zero-based index</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string AddPlaylistTracks(string userId, string playlistId, List<string> uris, int? position = null)
+        {
+            if (position == null)
+                return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks";
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks?position={position}";
+        }
+
+        /// <summary>
+        ///     Reorder a track or a group of tracks in a playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string ReorderPlaylist(string userId, string playlistId)
+        {
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks";
+        }
+
+        #endregion Playlists
+
+        #region Profiles
+
+        /// <summary>
+        ///     Get detailed profile information about the current user (including the current user’s username).
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetPrivateProfile()
+        {
+            return $"{APIBase}/me";
+        }
+
+        /// <summary>
+        ///     Get public profile information about a Spotify user.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <returns></returns>
+        public string GetPublicProfile(string userId)
+        {
+            return $"{APIBase}/users/{userId}";
+        }
+
+        #endregion Profiles
+
+        #region Tracks
+
+        /// <summary>
+        ///     Get Spotify catalog information for multiple tracks based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetSeveralTracks(List<string> ids, string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/tracks?ids={string.Join(",", ids.Take(50))}";
+            return $"{APIBase}/tracks?market={market}&ids={string.Join(",", ids.Take(50))}";
+        }
+
+        /// <summary>
+        ///     Get Spotify catalog information for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetTrack(string id, string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/tracks/{id}";
+            return $"{APIBase}/tracks/{id}?market={market}";
+        }
+
+        /// <summary>
+        ///     Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetAudioAnalysis(string id)
+        {
+            return $"{APIBase}/audio-analysis/{id}";
+        }
+
+        /// <summary>
+        ///     Get audio feature information for a single track identified by its unique Spotify ID.
+        /// </summary>
+        /// <param name="id">The Spotify ID for the track.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetAudioFeatures(string id)
+        {
+            return $"{APIBase}/audio-features/{id}";
+        }
+
+        /// <summary>
+        ///     Get audio features for multiple tracks based on their Spotify IDs.
+        /// </summary>
+        /// <param name="ids">A list of Spotify Track-IDs. Maximum: 100 IDs.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string GetSeveralAudioFeatures(List<string> ids)
+        {
+            return $"{APIBase}/audio-features?ids={string.Join(",", ids.Take(100))}";
+        }
+
+        #endregion Tracks
+
+        #region Player
+
+        /// <summary>
+        ///     Get information about a user’s available devices.
+        /// </summary>
+        /// <returns></returns>
+        public string GetDevices()
+        {
+            return $"{APIBase}/me/player/devices";
+        }
+
+        /// <summary>
+        ///     Get information about the user’s current playback state, including track, track progress, and active device.
+        /// </summary>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetPlayback(string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/me/player";
+            return $"{APIBase}/me/player?market={market}";
+        }
+
+        /// <summary>
+        ///     Get the object currently being played on the user’s Spotify account.
+        /// </summary>
+        /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+        /// <returns></returns>
+        public string GetPlayingTrack(string market = "")
+        {
+            if (string.IsNullOrEmpty(market))
+                return $"{APIBase}/me/player/currently-playing";
+            return $"{APIBase}/me/player/currently-playing?market={market}";
+        }
+
+        /// <summary>
+        ///     Transfer playback to a new device and determine if it should start playing.
+        /// </summary>
+        /// <returns></returns>
+        public string TransferPlayback()
+        {
+            return $"{APIBase}/me/player";
+        }
+
+        /// <summary>
+        ///     Start a new context or resume current playback on the user’s active device.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string ResumePlayback(string deviceId = "")
+        {
+            if(string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/play";
+            return $"{APIBase}/me/player/play?device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Pause playback on the user’s account.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string PausePlayback(string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/pause";
+            return $"{APIBase}/me/player/pause?device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Skips to next track in the user’s queue.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SkipPlaybackToNext(string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/next";
+            return $"{APIBase}/me/player/next?device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Skips to previous track in the user’s queue.
+        ///     Note that this will ALWAYS skip to the previous track, regardless of the current track’s progress.
+        ///     Returning to the start of the current track should be performed using the https://api.spotify.com/v1/me/player/seek endpoint.
+        /// </summary>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SkipPlaybackToPrevious(string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/previous";
+            return $"{APIBase}/me/player/previous?device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Seeks to the given position in the user’s currently playing track.
+        /// </summary>
+        /// <param name="positionMs">The position in milliseconds to seek to. Must be a positive number. 
+        /// Passing in a position that is greater than the length of the track will cause the player to start playing the next song.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SeekPlayback(int positionMs, string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/seek?position_ms={positionMs}";
+            return $"{APIBase}/me/player/seek?position_ms={positionMs}&device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Set the repeat mode for the user’s playback. Options are repeat-track, repeat-context, and off.
+        /// </summary>
+        /// <param name="repeatState">track, context or off.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SetRepeatMode(RepeatState repeatState, string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/repeat?state={repeatState.GetStringAttribute()}";
+            return $"{APIBase}/me/player/repeat?state={repeatState.GetStringAttribute()}&device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Set the volume for the user’s current playback device.
+        /// </summary>
+        /// <param name="volumePercent">Integer. The volume to set. Must be a value from 0 to 100 inclusive.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SetVolume(int volumePercent, string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/volume?volume_percent={volumePercent}";
+            return $"{APIBase}/me/player/volume?volume_percent={volumePercent}&device_id={deviceId}";
+        }
+
+        /// <summary>
+        ///     Toggle shuffle on or off for user’s playback.
+        /// </summary>
+        /// <param name="shuffle">True of False.</param>
+        /// <param name="deviceId">The id of the device this command is targeting. If not supplied, the user's currently active device is the target.</param>
+        /// <returns></returns>
+        public string SetShuffle(bool shuffle, string deviceId = "")
+        {
+            if (string.IsNullOrEmpty(deviceId))
+                return $"{APIBase}/me/player/shuffle?state={shuffle}";
+            return $"{APIBase}/me/player/shuffle?state={shuffle}&device_id={deviceId}";
+        }
+        #endregion
+    }
+}

--- a/SpotifyAPI.Core/Web/SpotifyWebClient.cs
+++ b/SpotifyAPI.Core/Web/SpotifyWebClient.cs
@@ -1,0 +1,212 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using SpotifyAPI.Web.Models;
+
+namespace SpotifyAPI.Web
+{
+    internal class SpotifyWebClient : IClient
+    {
+        public JsonSerializerSettings JsonSettings { get; set; }
+
+        public ProxyConfig ProxyConfig { get; set; }
+
+        private readonly Encoding _encoding = Encoding.UTF8;
+
+        public Tuple<ResponseInfo, string> Download(string url, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, byte[]> raw = DownloadRaw(url, headers);
+            return new Tuple<ResponseInfo, string>(raw.Item1, raw.Item2.Length > 0 ? _encoding.GetString(raw.Item2) : "{}");
+        }
+
+        public async Task<Tuple<ResponseInfo, string>> DownloadAsync(string url, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, byte[]> raw = await DownloadRawAsync(url, headers).ConfigureAwait(false);
+            return new Tuple<ResponseInfo, string>(raw.Item1, raw.Item2.Length > 0 ? _encoding.GetString(raw.Item2) : "{}");
+        }
+
+        public Tuple<ResponseInfo, byte[]> DownloadRaw(string url, Dictionary<string, string> headers = null)
+        {
+            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            using (HttpClient client = new HttpClient(clientHandler))
+            {
+                if (headers != null)
+                {
+                    foreach (KeyValuePair<string, string> headerPair in headers)
+                    {
+                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
+                    }
+                }
+                using (HttpResponseMessage response = Task.Run(() => client.GetAsync(url)).Result)
+                {
+                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
+                    {
+                        StatusCode = response.StatusCode,
+                        Headers = ConvertHeaders(response.Headers)
+                    }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
+                }
+            }
+        }
+
+        public async Task<Tuple<ResponseInfo, byte[]>> DownloadRawAsync(string url, Dictionary<string, string> headers = null)
+        {
+            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            using (HttpClient client = new HttpClient(clientHandler))
+            {
+                if (headers != null)
+                {
+                    foreach (KeyValuePair<string, string> headerPair in headers)
+                    {
+                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
+                    }
+                }
+                using (HttpResponseMessage response = await client.GetAsync(url).ConfigureAwait(false))
+                {
+                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
+                    {
+                        StatusCode = response.StatusCode,
+                        Headers = ConvertHeaders(response.Headers)
+                    }, await response.Content.ReadAsByteArrayAsync());
+                }
+            }
+        }
+
+        public Tuple<ResponseInfo, T> DownloadJson<T>(string url, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, string> response = Download(url, headers);
+            return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
+        }
+
+        public async Task<Tuple<ResponseInfo, T>> DownloadJsonAsync<T>(string url, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, string> response = await DownloadAsync(url, headers).ConfigureAwait(false);
+            return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
+        }
+
+        public Tuple<ResponseInfo, string> Upload(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, byte[]> data = UploadRaw(url, body, method, headers);
+            return new Tuple<ResponseInfo, string>(data.Item1, data.Item2.Length > 0 ? _encoding.GetString(data.Item2) : "{}");
+        }
+
+        public async Task<Tuple<ResponseInfo, string>> UploadAsync(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, byte[]> data = await UploadRawAsync(url, body, method, headers).ConfigureAwait(false);
+            return new Tuple<ResponseInfo, string>(data.Item1, data.Item2.Length > 0 ? _encoding.GetString(data.Item2) : "{}");
+        }
+
+        public Tuple<ResponseInfo, byte[]> UploadRaw(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            using (HttpClient client = new HttpClient(clientHandler))
+            {
+                if (headers != null)
+                {
+                    foreach (KeyValuePair<string, string> headerPair in headers)
+                    {
+                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
+                    }
+                }
+
+                HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+                {
+                    Content = new StringContent(body, _encoding)
+                };
+                using (HttpResponseMessage response = Task.Run(() => client.SendAsync(message)).Result)
+                {
+                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
+                    {
+                        StatusCode = response.StatusCode,
+                        Headers = ConvertHeaders(response.Headers)
+                    }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
+                }
+            }
+        }
+
+        public async Task<Tuple<ResponseInfo, byte[]>> UploadRawAsync(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            using (HttpClient client = new HttpClient(clientHandler))
+            {
+                if (headers != null)
+                {
+                    foreach (KeyValuePair<string, string> headerPair in headers)
+                    {
+                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
+                    }
+                }
+
+                HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+                {
+                    Content = new StringContent(body, _encoding)
+                };
+                using (HttpResponseMessage response = await client.SendAsync(message))
+                {
+                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
+                    {
+                        StatusCode = response.StatusCode,
+                        Headers = ConvertHeaders(response.Headers)
+                    }, await response.Content.ReadAsByteArrayAsync());
+                }
+            }
+        }
+
+        public Tuple<ResponseInfo, T> UploadJson<T>(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, string> response = Upload(url, body, method, headers);
+            return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
+        }
+
+        public async Task<Tuple<ResponseInfo, T>> UploadJsonAsync<T>(string url, string body, string method, Dictionary<string, string> headers = null)
+        {
+            Tuple<ResponseInfo, string> response = await UploadAsync(url, body, method, headers).ConfigureAwait(false);
+            return new Tuple<ResponseInfo, T>(response.Item1, JsonConvert.DeserializeObject<T>(response.Item2, JsonSettings));
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        private static WebHeaderCollection ConvertHeaders(HttpResponseHeaders headers)
+        {
+            WebHeaderCollection newHeaders = new WebHeaderCollection();
+            foreach (KeyValuePair<string, IEnumerable<string>> headerPair in headers)
+            {
+                foreach (string headerValue in headerPair.Value)
+                {
+                    newHeaders.Add(headerPair.Key, headerValue);
+                }
+            }
+            return newHeaders;
+        }
+
+        private static HttpClientHandler CreateClientHandler(ProxyConfig proxyConfig = null)
+        {
+            HttpClientHandler clientHandler = new HttpClientHandler
+            {
+                PreAuthenticate = false,
+                UseDefaultCredentials = true,
+                UseProxy = false
+            };
+
+            if (!string.IsNullOrWhiteSpace(proxyConfig?.Host))
+            {
+                WebProxy proxy = proxyConfig.CreateWebProxy();
+                clientHandler.UseProxy = true;
+                clientHandler.Proxy = proxy;
+                clientHandler.UseDefaultCredentials = proxy.UseDefaultCredentials;
+                clientHandler.PreAuthenticate = proxy.UseDefaultCredentials;
+            }
+
+            return clientHandler;
+        }
+    }
+}

--- a/SpotifyAPI.Core/Web/Util.cs
+++ b/SpotifyAPI.Core/Web/Util.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace SpotifyAPI.Web
+{
+    public static class Util
+    {
+        public static string GetStringAttribute<T>(this T en, string separator = "") where T : struct, IConvertible
+        {
+            Enum e = (Enum)(object)en;
+            IEnumerable<StringAttribute> attributes =
+            Enum.GetValues(typeof(T))
+            .Cast<T>()
+            .Where(v => e.HasFlag((Enum)(object)v))
+            .Select(v => typeof(T).GetField(v.ToString(CultureInfo.InvariantCulture)))
+            .Select(f => f.GetCustomAttributes(typeof(StringAttribute), false)[0])
+            .Cast<StringAttribute>();
+
+            List<string> list = new List<string>();
+            attributes.ToList().ForEach(element => list.Add(element.Text));
+            return string.Join(separator, list);
+        }
+
+        public static long ToUnixTimeMillisecondsPoly(this DateTime time)
+        {
+            return (long)time.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+        }
+    }
+
+    public sealed class StringAttribute : Attribute
+    {
+        public string Text { get; set; }
+
+        public StringAttribute(string text)
+        {
+            Text = text;
+        }
+    }
+}

--- a/SpotifyAPI.sln
+++ b/SpotifyAPI.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyAPI", "SpotifyAPI\SpotifyAPI.csproj", "{EBBE35E2-7B91-4D7D-B8FC-3A0472F5119D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyAPI.Tests", "SpotifyAPI.Tests\SpotifyAPI.Tests.csproj", "{A06CE1BA-B2C4-4C3C-9E79-D2E8D36DDF0B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyAPI.Example", "SpotifyAPI.Example\SpotifyAPI.Example.csproj", "{C8968A03-497E-4BAB-B492-5651AE7E0C06}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyAPI.Core", "SpotifyAPI.Core\SpotifyAPI.Core.csproj", "{0502DFB9-6B6F-4BDD-97E5-DDBA2BDE48C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,8 +29,15 @@ Global
 		{C8968A03-497E-4BAB-B492-5651AE7E0C06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8968A03-497E-4BAB-B492-5651AE7E0C06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8968A03-497E-4BAB-B492-5651AE7E0C06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0502DFB9-6B6F-4BDD-97E5-DDBA2BDE48C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0502DFB9-6B6F-4BDD-97E5-DDBA2BDE48C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0502DFB9-6B6F-4BDD-97E5-DDBA2BDE48C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0502DFB9-6B6F-4BDD-97E5-DDBA2BDE48C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {34E19BE3-41E7-4CFF-AE0D-DA9FCA8C42D4}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hi,

I don't really expect you to pull this _as is_, it's more of a FYI. 

I wanted to use your (super awesome) library from a .NET Core 2.0 console application. The [.NET Portability Analyzer](https://docs.microsoft.com/en-us/dotnet/standard/analyzers/portability-analyzer) suggested the majority of SpotifyAPI would natively run .NET Core so I quickly added a .NET Core 2.0 library project (SpotifyAPI.Core) and _copied_ all the files from SpotifyAPI into the new project.

Nearly everything compiled first time but I had to put in an additional workaround for the `Process.Start` call in `AutorizationCodeAuth`. Anyway, with these changes in place, I was successfully able to use the API from .NET Core 2.0.

So, you know, that's cool.

Let me know what you think and/or whether you'd like me to make further changes.

Cheers, Ian