### PR TITLE
Allow users to set ShowDialog when using WebAPIFactory

### DIFF
--- a/SpotifyAPI/Web/Auth/WebApiFactory.cs
+++ b/SpotifyAPI/Web/Auth/WebApiFactory.cs
@@ -42,13 +42,14 @@ namespace SpotifyAPI.Web.Auth
             _xss = xss;
         }
 
-        public Task<SpotifyWebAPI> GetWebApi()
+        public Task<SpotifyWebAPI> GetWebApi(bool showDialog = false)
         {
             var authentication = new ImplicitGrantAuth
             {
                 RedirectUri = new UriBuilder(_redirectUrl) { Port = _listeningPort }.Uri.OriginalString.TrimEnd('/'),
                 ClientId = _clientId,
                 Scope = _scope,
+                ShowDialog = showDialog,
                 State = _xss
             };
 


### PR DESCRIPTION
`ImplicitGrantAuth`'s `ShowDialog` property can now be set when using the `WebAPIFactory`.
This change addresses issue #238.