### PR TITLE
Updated the User-Agent header for the OAuth request

### DIFF
--- a/SpotifyAPI/Local/RemoteHandler.cs
+++ b/SpotifyAPI/Local/RemoteHandler.cs
@@ -186,7 +186,7 @@ namespace SpotifyAPI.Local
             {
                 Proxy = _config?.ProxyConfig?.CreateWebProxy()
             };
-            wc.Headers.Add(HttpRequestHeader.UserAgent, "Spotify (1.0.50.41368.gbd68dbef)");
+            wc.Headers.Add(HttpRequestHeader.UserAgent, "Spotify (1.0.85.257.g0f8531bd)");
 
             return wc;
         }


### PR DESCRIPTION
The User-Agent "Spotify (1.0.50.41368.gbd68dbef)" was returning an invalid OAuth token. I changed it to match the "client_version" returned on my local request. It solved my problem, but I'm not sure if this is the correct way to fix it.