### PR TITLE
Modified SpotifyWebClient to use a single HttpClient per class lifeti…

### DIFF
--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -23,15 +23,14 @@ namespace SpotifyAPI.Web
         {
             _builder = new SpotifyWebBuilder();
             UseAuth = true;
-            WebClient = new SpotifyWebClient
+            WebClient = new SpotifyWebClient(proxyConfig)
             {
                 JsonSettings =
                     new JsonSerializerSettings
                     {
                         NullValueHandling = NullValueHandling.Ignore,
                         TypeNameHandling = TypeNameHandling.All
-                    },
-                ProxyConfig = proxyConfig
+                    }
             };
         }
 

--- a/SpotifyAPI.Web/SpotifyWebClient.cs
+++ b/SpotifyAPI.Web/SpotifyWebClient.cs
@@ -13,15 +13,12 @@ namespace SpotifyAPI.Web
     internal class SpotifyWebClient : IClient
     {
         public JsonSerializerSettings JsonSettings { get; set; }
-
-        public ProxyConfig ProxyConfig { get; set; }
-
         private readonly Encoding _encoding = Encoding.UTF8;
         private readonly HttpClient _client;
 
-        public SpotifyWebClient()
+        public SpotifyWebClient(ProxyConfig proxyConfig = null)
         {
-            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            HttpClientHandler clientHandler = CreateClientHandler(proxyConfig);
             _client = new HttpClient(clientHandler);
         }
 

--- a/SpotifyAPI.Web/SpotifyWebClient.cs
+++ b/SpotifyAPI.Web/SpotifyWebClient.cs
@@ -17,6 +17,13 @@ namespace SpotifyAPI.Web
         public ProxyConfig ProxyConfig { get; set; }
 
         private readonly Encoding _encoding = Encoding.UTF8;
+        private readonly HttpClient _client;
+
+        public SpotifyWebClient()
+        {
+            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
+            _client = new HttpClient(clientHandler);
+        }
 
         public Tuple<ResponseInfo, string> Download(string url, Dictionary<string, string> headers = null)
         {
@@ -32,47 +39,39 @@ namespace SpotifyAPI.Web
 
         public Tuple<ResponseInfo, byte[]> DownloadRaw(string url, Dictionary<string, string> headers = null)
         {
-            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
-            using (HttpClient client = new HttpClient(clientHandler))
+            if (headers != null)
             {
-                if (headers != null)
+                foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    foreach (KeyValuePair<string, string> headerPair in headers)
-                    {
-                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
-                    }
+                    _client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
                 }
-                using (HttpResponseMessage response = Task.Run(() => client.GetAsync(url)).Result)
+            }
+            using (HttpResponseMessage response = Task.Run(() => _client.GetAsync(url)).Result)
+            {
+                return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
                 {
-                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
-                    {
-                        StatusCode = response.StatusCode,
-                        Headers = ConvertHeaders(response.Headers)
-                    }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
-                }
+                    StatusCode = response.StatusCode,
+                    Headers = ConvertHeaders(response.Headers)
+                }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
             }
         }
 
         public async Task<Tuple<ResponseInfo, byte[]>> DownloadRawAsync(string url, Dictionary<string, string> headers = null)
         {
-            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
-            using (HttpClient client = new HttpClient(clientHandler))
+            if (headers != null)
             {
-                if (headers != null)
+                foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    foreach (KeyValuePair<string, string> headerPair in headers)
-                    {
-                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
-                    }
+                    _client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
                 }
-                using (HttpResponseMessage response = await client.GetAsync(url).ConfigureAwait(false))
+            }
+            using (HttpResponseMessage response = await _client.GetAsync(url).ConfigureAwait(false))
+            {
+                return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
                 {
-                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
-                    {
-                        StatusCode = response.StatusCode,
-                        Headers = ConvertHeaders(response.Headers)
-                    }, await response.Content.ReadAsByteArrayAsync());
-                }
+                    StatusCode = response.StatusCode,
+                    Headers = ConvertHeaders(response.Headers)
+                }, await response.Content.ReadAsByteArrayAsync());
             }
         }
 
@@ -102,57 +101,49 @@ namespace SpotifyAPI.Web
 
         public Tuple<ResponseInfo, byte[]> UploadRaw(string url, string body, string method, Dictionary<string, string> headers = null)
         {
-            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
-            using (HttpClient client = new HttpClient(clientHandler))
+            if (headers != null)
             {
-                if (headers != null)
+                foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    foreach (KeyValuePair<string, string> headerPair in headers)
-                    {
-                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
-                    }
+                    _client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
                 }
+            }
 
-                HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+            HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+            {
+                Content = new StringContent(body, _encoding)
+            };
+            using (HttpResponseMessage response = Task.Run(() => _client.SendAsync(message)).Result)
+            {
+                return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
                 {
-                    Content = new StringContent(body, _encoding)
-                };
-                using (HttpResponseMessage response = Task.Run(() => client.SendAsync(message)).Result)
-                {
-                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
-                    {
-                        StatusCode = response.StatusCode,
-                        Headers = ConvertHeaders(response.Headers)
-                    }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
-                }
+                    StatusCode = response.StatusCode,
+                    Headers = ConvertHeaders(response.Headers)
+                }, Task.Run(() => response.Content.ReadAsByteArrayAsync()).Result);
             }
         }
 
         public async Task<Tuple<ResponseInfo, byte[]>> UploadRawAsync(string url, string body, string method, Dictionary<string, string> headers = null)
         {
-            HttpClientHandler clientHandler = CreateClientHandler(ProxyConfig);
-            using (HttpClient client = new HttpClient(clientHandler))
+            if (headers != null)
             {
-                if (headers != null)
+                foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    foreach (KeyValuePair<string, string> headerPair in headers)
-                    {
-                        client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
-                    }
+                    _client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
                 }
+            }
 
-                HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+            HttpRequestMessage message = new HttpRequestMessage(new HttpMethod(method), url)
+            {
+                Content = new StringContent(body, _encoding)
+            };
+            using (HttpResponseMessage response = await _client.SendAsync(message))
+            {
+                return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
                 {
-                    Content = new StringContent(body, _encoding)
-                };
-                using (HttpResponseMessage response = await client.SendAsync(message))
-                {
-                    return new Tuple<ResponseInfo, byte[]>(new ResponseInfo
-                    {
-                        StatusCode = response.StatusCode,
-                        Headers = ConvertHeaders(response.Headers)
-                    }, await response.Content.ReadAsByteArrayAsync());
-                }
+                    StatusCode = response.StatusCode,
+                    Headers = ConvertHeaders(response.Headers)
+                }, await response.Content.ReadAsByteArrayAsync());
             }
         }
 
@@ -170,6 +161,7 @@ namespace SpotifyAPI.Web
 
         public void Dispose()
         {
+            _client.Dispose();
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
Modified SpotifyWebClient to use a single HttpClient per class lifetime. This will allow the HttpClient to properly pool connections, and avoids SocketException errors under load.

From the Microsoft documentation: 
> HttpClient is intended to be instantiated once and reused throughout the life of an application. The following conditions can result in SocketException errors:
> - Creating a new HttpClient instance per request.
> - Server under heavy load.

Source: https://docs.microsoft.com/en-us/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client

In depth explanation:
https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/