### PR TITLE
Clear DefaultRequestHeaders when adding a new header dictionary

### DIFF
--- a/SpotifyAPI.Web/SpotifyWebClient.cs
+++ b/SpotifyAPI.Web/SpotifyWebClient.cs
@@ -166,12 +166,9 @@ namespace SpotifyAPI.Web
 
         private void AddHeaders(Dictionary<string,string> headers)
         {
+            _client.DefaultRequestHeaders.Clear();
             foreach (KeyValuePair<string, string> headerPair in headers)
             {
-                if (_client.DefaultRequestHeaders.Contains(headerPair.Key))
-                {
-                    _client.DefaultRequestHeaders.Remove(headerPair.Key);
-                }
                 _client.DefaultRequestHeaders.TryAddWithoutValidation(headerPair.Key, headerPair.Value);
             }
         }


### PR DESCRIPTION
Should fix the issue in this comment: https://github.com/JohnnyCrazy/SpotifyAPI-NET/pull/299#issuecomment-433590897