### PR TITLE
Support uploading an image for a playlist

### DIFF
--- a/SpotifyAPI.Web/Enums/Scope.cs
+++ b/SpotifyAPI.Web/Enums/Scope.cs
@@ -60,6 +60,9 @@ namespace SpotifyAPI.Web.Enums
         UserReadCurrentlyPlaying = 131072,
 
         [String("app-remote-control")]
-        AppRemoteControl = 262144
+        AppRemoteControl = 262144,
+
+        [String("ugc-image-upload")]
+        UgcImageUpload = 524288
     }
 }

--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -1523,6 +1523,30 @@ namespace SpotifyAPI.Web
         }
 
         /// <summary>
+        ///     Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="base64EncodedJpgImage">The image as a base64 encoded string</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse UploadPlaylistImage(string playlistId, string base64EncodedJpgImage)
+        {
+            return UploadData<ErrorResponse>(_builder.UploadPlaylistImage(playlistId), base64EncodedJpgImage, "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Change a playlist’s name and public/private state asynchronously. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="base64EncodedJpgImage">The image as a base64 encoded string</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> UploadPlaylistImageAsync(string playlistId, string base64EncodedJpgImage)
+        {
+            return (await UploadDataAsync<ErrorResponse>(_builder.UploadPlaylistImage(playlistId), base64EncodedJpgImage, "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
         ///     Replace all the tracks in a playlist, overwriting its existing tracks. This powerful request can be useful for
         ///     replacing tracks, re-ordering existing tracks, or clearing the playlist.
         /// </summary>

--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -1497,6 +1497,32 @@ namespace SpotifyAPI.Web
         }
 
         /// <summary>
+        ///     Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="base64EncodedJpgImage">The image as a base64 encoded string</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public ErrorResponse UploadPlaylistImage(string userId, string playlistId, string base64EncodedJpgImage)
+        {
+            return UploadData<ErrorResponse>(_builder.UploadPlaylistImage(userId, playlistId), base64EncodedJpgImage, "PUT") ?? new ErrorResponse();
+        }
+
+        /// <summary>
+        ///     Change a playlist’s name and public/private state asynchronously. (The user must, of course, own the playlist.)
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <param name="base64EncodedJpgImage">The image as a base64 encoded string</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public async Task<ErrorResponse> UploadPlaylistImageAsync(string userId, string playlistId, string base64EncodedJpgImage)
+        {
+            return (await UploadDataAsync<ErrorResponse>(_builder.UploadPlaylistImage(userId, playlistId), base64EncodedJpgImage, "PUT").ConfigureAwait(false)) ?? new ErrorResponse();
+        }
+
+        /// <summary>
         ///     Replace all the tracks in a playlist, overwriting its existing tracks. This powerful request can be useful for
         ///     replacing tracks, re-ordering existing tracks, or clearing the playlist.
         /// </summary>

--- a/SpotifyAPI.Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI.Web/SpotifyWebBuilder.cs
@@ -775,6 +775,17 @@ namespace SpotifyAPI.Web
             return $"{APIBase}/users/{userId}/playlists/{playlistId}/images";
         }
 
+        /// <summary>
+        ///     Upload an image for a playlist.
+        /// </summary>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string UploadPlaylistImage(string playlistId)
+        {
+            return $"{APIBase}/playlists/{playlistId}/images";
+        }
+
         #endregion Playlists
 
         #region Profiles

--- a/SpotifyAPI.Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI.Web/SpotifyWebBuilder.cs
@@ -763,6 +763,18 @@ namespace SpotifyAPI.Web
             return $"{APIBase}/users/{userId}/playlists/{playlistId}/tracks";
         }
 
+        /// <summary>
+        ///     Upload an image for a playlist.
+        /// </summary>
+        /// <param name="userId">The user's Spotify user ID.</param>
+        /// <param name="playlistId">The Spotify ID for the playlist.</param>
+        /// <returns></returns>
+        /// <remarks>AUTH NEEDED</remarks>
+        public string UploadPlaylistImage(string userId, string playlistId)
+        {
+            return $"{APIBase}/users/{userId}/playlists/{playlistId}/images";
+        }
+
         #endregion Playlists
 
         #region Profiles


### PR DESCRIPTION
This change allows uploading an image for a playlist.  This also requires the addition of a new authorization scope.  Image must be a base64 encoded jpeg image.

https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/