### PR TITLE
Auto-Closing window for ImplicitGrantAuthController

### DIFF
--- a/SpotifyAPI.Web.Auth/ImplicitGrantAuth.cs
+++ b/SpotifyAPI.Web.Auth/ImplicitGrantAuth.cs
@@ -55,7 +55,7 @@ namespace SpotifyAPI.Web.Auth
             }
 
             Task.Factory.StartNew(() => auth.TriggerAuth(token));
-            return this.StringResponseAsync("OK - This window can be closed now");
+            return this.StringResponseAsync("<html><script type=\"text/javascript\">window.close();</script>OK - This window can be closed now</html>");
         }
 
         public ImplicitGrantAuthController(IHttpContext context) : base(context)


### PR DESCRIPTION
In case we have multiple authentications (e.g. after token timeout) there may be several open windows caused by authentication redirect. 
With different response the web browser will close the window automatically, 
In worst case (e.g. no javascript) the original message will be displayed.