### PR TITLE
Fix TokenSwapAuth html response returning string

### DIFF
--- a/SpotifyAPI.Web.Auth/TokenSwapAuth.cs
+++ b/SpotifyAPI.Web.Auth/TokenSwapAuth.cs
@@ -211,7 +211,7 @@ namespace SpotifyAPI.Web.Auth
                 Code = code,
                 Error = error
             }));
-            return this.StringResponseAsync(((TokenSwapAuth)auth).HtmlResponse);
+            return this.HtmlResponseAsync(((TokenSwapAuth)auth).HtmlResponse);
         }
     }
 }


### PR DESCRIPTION
This should make the window actually close, instead of just showing a string containing the javascript :)