### PR TITLE
Fix: Change response-type of ImplicitGrantAuthController

### DIFF
--- a/SpotifyAPI.Web.Auth/ImplicitGrantAuth.cs
+++ b/SpotifyAPI.Web.Auth/ImplicitGrantAuth.cs
@@ -55,7 +55,7 @@ namespace SpotifyAPI.Web.Auth
             }
 
             Task.Factory.StartNew(() => auth.TriggerAuth(token));
-            return this.StringResponseAsync("<html><script type=\"text/javascript\">window.close();</script>OK - This window can be closed now</html>");
+            return this.HtmlResponseAsync("<html><script type=\"text/javascript\">window.close();</script>OK - This window can be closed now</html>");
         }
 
         public ImplicitGrantAuthController(IHttpContext context) : base(context)


### PR DESCRIPTION
String response will set wrong http-content type and browser will not execute javascript code
Html content type will fix this