### PR TITLE
Typo Fix in HasPreviousPage method

### DIFF
--- a/SpotifyAPI.Web/Models/Paging.cs
+++ b/SpotifyAPI.Web/Models/Paging.cs
@@ -33,7 +33,7 @@ namespace SpotifyAPI.Web.Models
 
         public bool HasPreviousPage()
         {
-            return Next != null;
+            return Previous != null;
         }
     }
 }


### PR DESCRIPTION
HasPreviousPage() was returning the status of Next instead of Previous