### PR TITLE
Adding support for Podcasts

### DIFF
--- a/SpotifyAPI.Web.Examples.ASP/Properties/launchSettings.json
+++ b/SpotifyAPI.Web.Examples.ASP/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
@@ -18,10 +18,10 @@
     "SpotifyAPI.Web.Examples.ASP": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "http://localhost:5000"
     }
   }
 }

--- a/SpotifyAPI.Web/Enums/Scope.cs
+++ b/SpotifyAPI.Web/Enums/Scope.cs
@@ -63,6 +63,10 @@ namespace SpotifyAPI.Web.Enums
     AppRemoteControl = 262144,
 
     [String("ugc-image-upload")]
-    UgcImageUpload = 524288
-  }
+    UgcImageUpload = 524288,
+
+    [String("user-read-playback-position")]
+    UserReadPlaybackPosition = 1048576
+
+    }
 }

--- a/SpotifyAPI.Web/Models/FullEpisode.cs
+++ b/SpotifyAPI.Web/Models/FullEpisode.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using SpotifyAPI.Web.Enums;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class FullEpisode : BasicModel,IItem
+    {
+        public TrackType ItemType => TrackType.Episode;
+
+        [JsonProperty("audio_preview_url")]
+        public string AudioPreviewUrl { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int DurationMs { get; set; }
+
+        [JsonProperty("explicit")]
+        public bool Explicit { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("is_externally_hosted")]
+        public bool IsExternallyHosted { get; set; }
+
+        [JsonProperty("is_playable")]
+        public bool IsPlayable { get; set; }
+
+        [JsonProperty("languages")]
+        public List<string> Languages { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("release_date")]
+        public string ReleaseDate { get; set; }
+
+        [JsonProperty("release_date_precision")]
+        public string ReleaseDatePrecision { get; set; }    
+
+        [JsonProperty("resume_point")]
+        public ResumePointObject ResumePoint { get; set; }
+
+        [JsonProperty("show")]
+        public SimpleShow Show { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+    }
+}

--- a/SpotifyAPI.Web/Models/FullTrack.cs
+++ b/SpotifyAPI.Web/Models/FullTrack.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using SpotifyAPI.Web.Enums;
 using Newtonsoft.Json;
 
 namespace SpotifyAPI.Web.Models
 {
-  public class FullTrack : BasicModel
+  public class FullTrack : BasicModel, IItem
   {
+    public TrackType ItemType => TrackType.Track;
+
     [JsonProperty("album")]
     public SimpleAlbum Album { get; set; }
 

--- a/SpotifyAPI.Web/Models/GeneralModels.cs
+++ b/SpotifyAPI.Web/Models/GeneralModels.cs
@@ -56,7 +56,8 @@ namespace SpotifyAPI.Web.Models
     public PublicProfile AddedBy { get; set; }
 
     [JsonProperty("track")]
-    public FullTrack Track { get; set; }
+    [JsonConverter(typeof(PlaylistTrackConverter))]
+    public IItem Track { get; set; }
 
     [JsonProperty("is_local")]
     public bool IsLocal { get; set; }

--- a/SpotifyAPI.Web/Models/PlaybackContext.cs
+++ b/SpotifyAPI.Web/Models/PlaybackContext.cs
@@ -1,11 +1,18 @@
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using SpotifyAPI.Web.Enums;
 
 namespace SpotifyAPI.Web.Models
 {
-  public class PlaybackContext : BasicModel
-  {
+    public interface IItem
+    {
+        TrackType ItemType { get; }
+    }
+
+    [JsonConverter(typeof(PlaybackContextConverter))]
+    public class PlaybackContext : BasicModel
+    { 
     [JsonProperty("device")]
     public Device Device { get; set; }
 
@@ -29,7 +36,7 @@ namespace SpotifyAPI.Web.Models
     public bool IsPlaying { get; set; }
 
     [JsonProperty("item")]
-    public FullTrack Item { get; set; }
+    public IItem Item { get; set; }
 
     [JsonProperty("currently_playing_type")]
     [JsonConverter(typeof(StringEnumConverter))]

--- a/SpotifyAPI.Web/Models/PlaybackContextConverter.cs
+++ b/SpotifyAPI.Web/Models/PlaybackContextConverter.cs
@@ -20,13 +20,16 @@ namespace SpotifyAPI.Web.Models
             // Create an instance of MyClass, and set property as per "isFoo".
             var obj = new PlaybackContext();
 
-            if (token["currently_playing_type"].Value<string>() == "track")
+            if (token["currently_playing_type"] != null)
             {
-                obj.Item = new FullTrack();
-            }
-            else if (token["currently_playing_type"].Value<string>() == "episode")
-            {
-                obj.Item = new FullEpisode();
+                if (token["currently_playing_type"].Value<string>() == "track")
+                {
+                    obj.Item = new FullTrack();
+                }
+                else if (token["currently_playing_type"].Value<string>() == "episode")
+                {
+                    obj.Item = new FullEpisode();
+                }
             }
 
             // Populate properties

--- a/SpotifyAPI.Web/Models/PlaybackContextConverter.cs
+++ b/SpotifyAPI.Web/Models/PlaybackContextConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SpotifyAPI.Web.Models
+{
+    class PlaybackContextConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => true;
+
+        public override object ReadJson(JsonReader reader, Type objectType,
+            object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.ReadFrom(reader);
+            if (token.Type == JTokenType.Null)
+            {
+                return null;
+            }
+
+            // Create an instance of MyClass, and set property as per "isFoo".
+            var obj = new PlaybackContext();
+
+            if (token["currently_playing_type"].Value<string>() == "track")
+            {
+                obj.Item = new FullTrack();
+            }
+            else if (token["currently_playing_type"].Value<string>() == "episode")
+            {
+                obj.Item = new FullEpisode();
+            }
+
+            // Populate properties
+            serializer.Populate(token.CreateReader(), obj);
+            return obj;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value,
+            JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/SpotifyAPI.Web/Models/PlaylistTrackConverter.cs
+++ b/SpotifyAPI.Web/Models/PlaylistTrackConverter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SpotifyAPI.Web.Models
+{
+    class PlaylistTrackConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => true;
+
+        public override object ReadJson(JsonReader reader, Type objectType,
+            object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.ReadFrom(reader);
+            if (token.Type == JTokenType.Null)
+            {
+                return null;
+            }
+
+            if (token["track"] == null)
+            {
+                return null;
+            }
+
+            if (token["track"].Value<bool>() == true)
+            {
+                var obj = new FullTrack();
+                serializer.Populate(token.CreateReader(), obj);
+                return obj;
+            }
+            else 
+            {
+                var obj = new FullEpisode();
+                serializer.Populate(token.CreateReader(), obj);
+                return obj;
+            }            
+        }
+
+        public override void WriteJson(JsonWriter writer, object value,
+            JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/SpotifyAPI.Web/Models/ResumePointObject.cs
+++ b/SpotifyAPI.Web/Models/ResumePointObject.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class ResumePointObject : BasicModel
+    {
+        [JsonProperty("fully_played")]
+        public bool FullyPlayed { get; set; }
+
+        [JsonProperty("resume_position_ms")]
+        public int ResumePositionMs { get; set; }
+    }
+}

--- a/SpotifyAPI.Web/Models/SeveralShows.cs
+++ b/SpotifyAPI.Web/Models/SeveralShows.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SeveralShows : BasicModel
+    {
+        [JsonProperty("shows")]
+        public List<SimpleShow> Shows { get; set; }
+    }
+}

--- a/SpotifyAPI.Web/Models/SimpleEpisode.cs
+++ b/SpotifyAPI.Web/Models/SimpleEpisode.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimpleEpisode : BasicModel
+    {
+        [JsonProperty("audio_preview_url")]
+        public string AudioPreviewUrl { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int DurationMs { get; set; }
+
+        [JsonProperty("explicit")]
+        public bool Explicit { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("is_externally_hosted")]
+        public bool IsExternallyHosted { get; set; }
+
+        [JsonProperty("is_playable")]
+        public bool IsPlayable { get; set; }
+
+        [JsonProperty("languages")]
+        public List<string> Languages { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("release_date")]
+        public string ReleaseDate { get; set; }
+
+        [JsonProperty("resume_point")]
+        public ResumePointObject ResumePoint { get; set; }
+
+        [JsonProperty("show")]
+        public SimpleShow Show { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+    }
+}

--- a/SpotifyAPI.Web/Models/SimpleShow.cs
+++ b/SpotifyAPI.Web/Models/SimpleShow.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class SimpleShow : BasicModel
+    {
+        [JsonProperty("available_markets")]
+        public List<string> AvailableMarkets { get; set; }
+
+        [JsonProperty("copyrights")]
+        public List<Copyright> Copyrights { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("explicit")]
+        public bool Explicit { get; set; }
+
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("images")]
+        public List<Image> Images { get; set; }
+
+        [JsonProperty("is_externally_hosted")]
+        public bool IsExternallyHosted { get; set; }
+
+        [JsonProperty("languages")]
+        public List<string> Languages { get; set; }
+
+        [JsonProperty("media_type")]
+        public string MediaType { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("publisher")]
+        public string Publisher { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+    }
+}

--- a/SpotifyAPI.Web/Models/SimpleTrack.cs
+++ b/SpotifyAPI.Web/Models/SimpleTrack.cs
@@ -5,6 +5,9 @@ namespace SpotifyAPI.Web.Models
 {
   public class SimpleTrack : BasicModel
   {
+    [JsonProperty("album")]
+    public SimpleAlbum Album { get; set; }
+
     [JsonProperty("artists")]
     public List<SimpleArtist> Artists { get; set; }
 
@@ -19,6 +22,9 @@ namespace SpotifyAPI.Web.Models
 
     [JsonProperty("explicit")]
     public bool Explicit { get; set; }
+       
+    [JsonProperty("external_ids")]
+    public Dictionary<string, string> ExternIds { get; set; }
 
     [JsonProperty("external_urls")]
     public Dictionary<string, string> ExternUrls { get; set; }
@@ -29,8 +35,17 @@ namespace SpotifyAPI.Web.Models
     [JsonProperty("id")]
     public string Id { get; set; }
 
+    [JsonProperty("is_playable")]
+    public bool IsPlayable { get; set; }
+
+    [JsonProperty("linked_from")]
+    public TrackLink LinkedFrom { get; set; }
+        
     [JsonProperty("name")]
     public string Name { get; set; }
+
+    [JsonProperty("popularity")]
+    public int Popularity { get; set; }
 
     [JsonProperty("preview_url")]
     public string PreviewUrl { get; set; }

--- a/SpotifyAPI.Web/Models/TrackLink.cs
+++ b/SpotifyAPI.Web/Models/TrackLink.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SpotifyAPI.Web.Models
+{
+    public class TrackLink : BasicModel
+    {
+        [JsonProperty("external_urls")]
+        public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -2269,6 +2269,10 @@ namespace SpotifyAPI.Web
             {
                 return uri.Replace("spotify:episode:", "");
             }
+            else if (uri.Contains("spotify:playlist:"))
+            {
+                return uri.Replace("spotify:playlist:", "");
+            }
             else
                 return uri;
         }

--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -2194,7 +2194,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public SimpleShow GetShow(string id, string market = "")
     {
-            return DownloadData<SimpleShow>(_builder.GetShow(RemovePrefix(id), market));
+            return DownloadData<SimpleShow>(_builder.GetShow(id, market));
     }
 
     /// <summary>
@@ -2205,7 +2205,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public Task<SimpleShow> GetShowAsync(string id, string market = "")
     {
-        return DownloadDataAsync<SimpleShow>(_builder.GetShow(RemovePrefix(id), market));
+        return DownloadDataAsync<SimpleShow>(_builder.GetShow(id, market));
     }
 
 
@@ -2217,7 +2217,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public Task<SeveralShows> GetShowsAsync(List<string> ids, string market = "")
     {
-            return DownloadDataAsync<SeveralShows>(_builder.GetShows(RemovePrefix(ids), market));
+            return DownloadDataAsync<SeveralShows>(_builder.GetShows(ids, market));
     }
 
     /// <summary>
@@ -2228,10 +2228,15 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public SeveralShows GetShows(List<string> ids, string market = "")
     {
-        return DownloadData<SeveralShows>(_builder.GetShows(RemovePrefix(ids), market));
+        return DownloadData<SeveralShows>(_builder.GetShows(ids, market));
     }
 
-    List<string> RemovePrefix(List<string> uris)
+    /// <summary>
+    ///    A Helper function that removes the spotify:XXX: prefix for several uris.
+    /// </summary>
+    /// <param name="uris">A list of full spotify uris</param>
+    /// <returns>A list of uris without the spotify prefix.</returns>
+    public List<string> RemovePrefix(List<string> uris)
     {
         List<string> fixed_uris = new List<string>();
         foreach (var uri in uris)
@@ -2241,7 +2246,13 @@ namespace SpotifyAPI.Web
         return fixed_uris;
     }
 
-    string RemovePrefix(string uri)
+    /// <summary>
+    ///    A Helper function that removes the spotify:XXX: prefix for a single uri.
+    /// </summary>
+    /// <param name="uri">A spotify uri (e.g.,spotify:XXX:YYY). </param>
+    /// <returns>Uri without the prefix (e.g. YYY).</returns>
+ 
+    public string RemovePrefix(string uri)
         {
             if (uri.Contains("spotify:show:"))
             {
@@ -2272,7 +2283,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public Paging<SimpleEpisode> GetShowEpisodes(string id, int limit = 20, int offset = 0, string market = "")
     {        
-        return DownloadData<Paging<SimpleEpisode>>(_builder.GetShowEpisodes(RemovePrefix(id), limit, offset, market));
+        return DownloadData<Paging<SimpleEpisode>>(_builder.GetShowEpisodes(id, limit, offset, market));
     }
 
     /// <summary>
@@ -2285,7 +2296,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     public Task<Paging<FullEpisode>> GetShowEpisodesAsync(string id, int limit = 20, int offset = 0, string market = "")
     {
-        return DownloadDataAsync<Paging<FullEpisode>>(_builder.GetShowEpisodes(RemovePrefix(id), limit, offset, market));
+        return DownloadDataAsync<Paging<FullEpisode>>(_builder.GetShowEpisodes(id, limit, offset, market));
     }
 
     #endregion Shows

--- a/SpotifyAPI.Web/SpotifyWebAPI.cs
+++ b/SpotifyAPI.Web/SpotifyWebAPI.cs
@@ -613,6 +613,54 @@ namespace SpotifyAPI.Web
 
     #endregion Browse
 
+    #region Episode
+    /// <summary>
+    ///    Get Spotify catalog information for a single episode identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the episode.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public FullEpisode GetEpisode(string id, string market = "")
+    {
+        return DownloadData<FullEpisode>(_builder.GetEpisode(id, market));
+    }
+    /// <summary>
+    ///    Get Spotify catalog information for a single episode identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the episode.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public Task<FullEpisode> GetEpisodeAsync(string id, string market = "")
+    {
+        return DownloadDataAsync<FullEpisode>(_builder.GetEpisode(id, market));
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple episodes based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public ListResponse<FullEpisode> GetEpisodes(string id, string market = "")
+   {
+       return DownloadList<FullEpisode>(_builder.GetEpisode(id, market));
+   }
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple episodes based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public Task<ListResponse<FullEpisode>> GetEpisodesAsync(string id, string market = "")
+    {
+        return DownloadListAsync<FullEpisode>(_builder.GetEpisode(id, market));
+    }
+
+   
+
+    #endregion Episode
+
     #region Follow
 
     /// <summary>
@@ -624,7 +672,7 @@ namespace SpotifyAPI.Web
     /// <returns></returns>
     /// <remarks>AUTH NEEDED</remarks>
     public FollowedArtists GetFollowedArtists(FollowType followType, int limit = 20, string after = "")
-    {
+{
       if (!UseAuth)
         throw new InvalidOperationException("Auth is required for GetFollowedArtists");
       return DownloadData<FollowedArtists>(_builder.GetFollowedArtists(limit, after));
@@ -2135,6 +2183,112 @@ namespace SpotifyAPI.Web
     }
 
     #endregion Profiles
+
+    #region Shows
+
+    /// <summary>
+    ///    Get Spotify catalog information for a single show identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the show.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public SimpleShow GetShow(string id, string market = "")
+    {
+            return DownloadData<SimpleShow>(_builder.GetShow(RemovePrefix(id), market));
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information for a single show identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the show.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public Task<SimpleShow> GetShowAsync(string id, string market = "")
+    {
+        return DownloadDataAsync<SimpleShow>(_builder.GetShow(RemovePrefix(id), market));
+    }
+
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple shows based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public Task<SeveralShows> GetShowsAsync(List<string> ids, string market = "")
+    {
+            return DownloadDataAsync<SeveralShows>(_builder.GetShows(RemovePrefix(ids), market));
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple shows based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public SeveralShows GetShows(List<string> ids, string market = "")
+    {
+        return DownloadData<SeveralShows>(_builder.GetShows(RemovePrefix(ids), market));
+    }
+
+    List<string> RemovePrefix(List<string> uris)
+    {
+        List<string> fixed_uris = new List<string>();
+        foreach (var uri in uris)
+        {
+            fixed_uris.Add(RemovePrefix(uri));
+        }
+        return fixed_uris;
+    }
+
+    string RemovePrefix(string uri)
+        {
+            if (uri.Contains("spotify:show:"))
+            {
+                return uri.Replace("spotify:show:", "");
+            } else if (uri.Contains("spotify:track:"))
+            {
+                return uri.Replace("spotify:track:", "");
+            }
+            else if (uri.Contains("spotify:album:"))
+            {
+                return uri.Replace("spotify:album:", "");
+            }
+            else if (uri.Contains("spotify:episode:"))
+            {
+                return uri.Replace("spotify:episode:", "");
+            }
+            else
+                return uri;
+        }
+
+    /// <summary>
+    ///    Get Spotify catalog information about an show’s episodes. Optional parameters can be used to limit the number of episodes returned.
+    /// </summary>
+    /// <param name="id">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+    /// <param name="limit">The maximum number of episodes to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+    /// <param name="offset">The index of the first episode to return. Default: 0 (the first object). Use with limit to get the next set of episodes.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public Paging<SimpleEpisode> GetShowEpisodes(string id, int limit = 20, int offset = 0, string market = "")
+    {        
+        return DownloadData<Paging<SimpleEpisode>>(_builder.GetShowEpisodes(RemovePrefix(id), limit, offset, market));
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information about an show’s episodes. Optional parameters can be used to limit the number of episodes returned.
+    /// </summary>
+    /// <param name="id">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+    /// <param name="limit">The maximum number of episodes to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+    /// <param name="offset">The index of the first episode to return. Default: 0 (the first object). Use with limit to get the next set of episodes.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public Task<Paging<FullEpisode>> GetShowEpisodesAsync(string id, int limit = 20, int offset = 0, string market = "")
+    {
+        return DownloadDataAsync<Paging<FullEpisode>>(_builder.GetShowEpisodes(RemovePrefix(id), limit, offset, market));
+    }
+
+    #endregion Shows
 
     #region Tracks
 

--- a/SpotifyAPI.Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI.Web/SpotifyWebBuilder.cs
@@ -339,6 +339,37 @@ namespace SpotifyAPI.Web
 
     #endregion Browse
 
+
+
+    #region Episode
+    /// <summary>
+    ///    Get Spotify catalog information for a single episode identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the episode.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public string GetEpisode(string id, string market = "")
+    {
+        return string.IsNullOrEmpty(market) ?
+            $"{APIBase}/episodes/{id}" :
+            $"{APIBase}/episodes?market={market}&id={id}";
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple episodes based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public string GetEpisodes(List<string> ids, string market = "")
+    {
+        return string.IsNullOrEmpty(market) ?
+            $"{APIBase}/episodes?ids={string.Join(",", ids.Take(50))}" :
+        $"{APIBase}/episodes?market={market}&ids={string.Join(",", ids.Take(50))}";
+    }
+    #endregion Episode
+
+
     #region Follow
 
     /// <summary>
@@ -532,6 +563,39 @@ namespace SpotifyAPI.Web
     public string CheckSavedAlbums(List<string> ids)
     {
       return APIBase + "/me/albums/contains?ids=" + string.Join(",", ids);
+    }
+
+    /// <summary>
+    ///     Save one or more shows to current Spotify user’s library.
+    /// </summary>
+    // <param name="ids">A list of the Spotify IDs.</param>
+    /// <returns></returns>
+    /// <remarks>AUTH NEEDED (user-library-modify)</remarks>
+    public string SubscribeShows(List<string> ids)
+    {
+      return $"{APIBase}/me/shows?ids={string.Join(",", ids.Take(50))}";
+    }
+
+    /// <summary>
+    ///     Check if one or more shows is already saved in the current Spotify user’s library.
+    /// </summary>
+    // <param name="ids">A list of the Spotify IDs.</param>
+    /// <returns></returns>
+    /// <remarks>AUTH NEEDED (user-library-modify)</remarks>
+    public string CheckSubscribedShows(List<string> ids)
+    {
+        return $"{APIBase}/me/shows/contains?ids={string.Join(",", ids.Take(50))}";
+    }
+
+    /// <summary>
+    ///     Delete one or more shows from current Spotify user’s library.
+    /// </summary>
+    /// <param name="ids">A list of the Spotify IDs.</param>
+    /// <returns></returns>
+    /// <remarks>AUTH NEEDED (user-library-modify)</remarks>
+    public string UnsubscribeShows(List<string> ids)
+    {
+        return $"{APIBase}/me/shows?ids={string.Join(",", ids.Take(50))}";
     }
 
     #endregion Library
@@ -912,6 +976,53 @@ namespace SpotifyAPI.Web
 
     #endregion Profiles
 
+    #region Shows
+
+    /// <summary>
+    ///    Get Spotify catalog information for a single show identified by its unique Spotify ID.
+    /// </summary>
+    /// <param name="id">The Spotify ID for the show.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public string GetShow(string id, string market = "")
+    {
+        return string.IsNullOrEmpty(market) ?
+            $"{APIBase}/shows/{id}" :
+            $"{APIBase}/shows?market={market}&id={id}";
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information for multiple shows based on their Spotify IDs.
+    /// </summary>
+    /// <param name="ids">A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.</param>
+    /// <param name="market">Optional. An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows and episodes that are available in that market will be returned. If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter. Note: If neither market or user country are provided, the content is considered unavailable for the client.Users can view the country that is associated with their account in the account settings.</param>
+    /// <returns></returns>
+    public string GetShows(List<string> ids, string market = "")
+    {
+        return string.IsNullOrEmpty(market) ?
+            $"{APIBase}/shows?ids={string.Join(",", ids.Take(50))}"  :
+        $"{APIBase}/shows?market={market}&ids={string.Join(",", ids.Take(50))}";
+    }
+
+    /// <summary>
+    ///    Get Spotify catalog information about an show’s episodes. Optional parameters can be used to limit the number of episodes returned.
+    /// </summary>
+    /// <param name="id">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
+    /// <param name="limit">The maximum number of episodes to return. Default: 20. Minimum: 1. Maximum: 50.</param>
+    /// <param name="offset">The index of the first episode to return. Default: 0 (the first object). Use with limit to get the next set of episodes.</param>
+    /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <returns></returns>
+    public string GetShowEpisodes(string id, int limit = 20, int offset = 0, string market = "")
+    {
+        return string.IsNullOrEmpty(market) ?
+            $"{APIBase}/shows/{id}/episodes?offset={offset}&limit={limit}" :
+            $"{APIBase}/shows/{id}/episodes?market={market}&offset={offset}&limit={limit}";
+    }
+
+    #endregion Shows
+
+
+
     #region Tracks
 
     /// <summary>
@@ -920,7 +1031,7 @@ namespace SpotifyAPI.Web
     /// <param name="ids">A list of the Spotify IDs for the tracks. Maximum: 50 IDs.</param>
     /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
     /// <returns></returns>
-    public string GetSeveralTracks(List<string> ids, string market = "")
+        public string GetSeveralTracks(List<string> ids, string market = "")
     {
       return string.IsNullOrEmpty(market) ?
         $"{APIBase}/tracks?ids={string.Join(",", ids.Take(50))}" :
@@ -988,22 +1099,24 @@ namespace SpotifyAPI.Web
     ///     Get information about the user’s current playback state, including track, track progress, and active device.
     /// </summary>
     /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <param name="additional_types">A comma-separated list of item types that your client supports besides the default track type. Valid types are: track and episode. An unsupported type in the response is expected to be represented as null value in the item field. Note: This parameter was introduced to allow existing clients to maintain their current behaviour and might be deprecated in the future. In addition to providing this parameter, make sure that your client properly handles cases of new types in the future by checking against the currently_playing_type field..</param>
     /// <returns></returns>
-    public string GetPlayback(string market = "")
+    public string GetPlayback(string market = "", string additional_types = "track,episode")
     {
-      return string.IsNullOrEmpty(market) ? $"{APIBase}/me/player" : $"{APIBase}/me/player?market={market}";
+      return string.IsNullOrEmpty(market) ? $"{APIBase}/me/player?additional_types={additional_types}" : $"{APIBase}/me/player?market={market}&additional_types={additional_types}";
     }
 
     /// <summary>
     ///     Get the object currently being played on the user’s Spotify account.
     /// </summary>
     /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <param name="additional_types">A comma-separated list of item types that your client supports besides the default track type. Valid types are: track and episode. An unsupported type in the response is expected to be represented as null value in the item field. Note: This parameter was introduced to allow existing clients to maintain their current behaviour and might be deprecated in the future. In addition to providing this parameter, make sure that your client properly handles cases of new types in the future by checking against the currently_playing_type field..</param>
     /// <returns></returns>
-    public string GetPlayingTrack(string market = "")
+    public string GetPlayingTrack(string market = "", string additional_types= "track,episode")
     {
       return string.IsNullOrEmpty(market) ?
-        $"{APIBase}/me/player/currently-playing" :
-        $"{APIBase}/me/player/currently-playing?market={market}";
+        $"{APIBase}/me/player/currently-playing?additional_types={additional_types}" :
+        $"{APIBase}/me/player/currently-playing?market={market}&additional_types={additional_types}";
     }
 
     /// <summary>

--- a/SpotifyAPI.Web/SpotifyWebBuilder.cs
+++ b/SpotifyAPI.Web/SpotifyWebBuilder.cs
@@ -761,9 +761,10 @@ namespace SpotifyAPI.Web
     /// <param name="limit">The maximum number of tracks to return. Default: 100. Minimum: 1. Maximum: 100.</param>
     /// <param name="offset">The index of the first object to return. Default: 0 (i.e., the first object)</param>
     /// <param name="market">An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply Track Relinking.</param>
+    /// <param name="additional_types">A comma-separated list of item types that your client supports besides the default track type. Valid types are: track and episode. An unsupported type in the response is expected to be represented as null value in the item field. Note: This parameter was introduced to allow existing clients to maintain their current behaviour and might be deprecated in the future. In addition to providing this parameter, make sure that your client properly handles cases of new types in the future by checking against the currently_playing_type field..</param>
     /// <returns></returns>
     /// <remarks>AUTH NEEDED</remarks>
-    public string GetPlaylistTracks(string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "")
+    public string GetPlaylistTracks(string playlistId, string fields = "", int limit = 100, int offset = 0, string market = "", string additional_types = "track,episode")
     {
       limit = Math.Min(limit, 100);
       StringBuilder builder = new StringBuilder(APIBase + "/playlists/" + playlistId + "/tracks");
@@ -771,7 +772,13 @@ namespace SpotifyAPI.Web
       builder.Append("&limit=" + limit);
       builder.Append("&offset=" + offset);
       if (!string.IsNullOrEmpty(market))
-        builder.Append("&market=" + market);
+      {
+          builder.Append("&market=" + market);
+      }
+      if (!string.IsNullOrEmpty(additional_types))
+      {
+          builder.Append("&additional_types=" + additional_types);
+      }
       return builder.ToString();
     }
 


### PR DESCRIPTION
Adding new models that represent Show and Episodes.
Modified several functions to support returning both tracks and episodes. The major change is in PlaybackContext Item field that is now an interface. This solves the issue that the same returned json field (item) can be either a track or an episode.