### PR TITLE
Fix duplicate '?' in query part of URI

### DIFF
--- a/SpotifyAPI.Web/Util/URIExtension.cs
+++ b/SpotifyAPI.Web/Util/URIExtension.cs
@@ -29,7 +29,7 @@ namespace SpotifyAPI.Web
       }
 
       var queryString = string.Join("&", newParameters.Select((parameter) => $"{parameter.Key}={parameter.Value}"));
-      var query = string.IsNullOrEmpty(queryString) ? null : $"?{queryString}";
+      var query = string.IsNullOrEmpty(queryString) ? null : queryString;
 
       var uriBuilder = new UriBuilder(uri)
       {


### PR DESCRIPTION
Upon playing around with version 6 of the API I noticed that it threw errors despite everything being setup correctly when trying to set the volume.

I'm not entirely sure why it happens, all I know is that it has something to do with `System.UriBuilder`.
It produces an additional `?` despite there already being one there, and from reading the sources for [UriBuilder](https://source.dot.net/#System.Private.Uri/System/UriBuilder.cs,72b5344a210b74aa) it should already check for that, hence why I'm not entirely sure why it happens.

Nevertheless, this is a quick fix to go around the issue.

![image](https://user-images.githubusercontent.com/22471295/84535135-7cd75400-aceb-11ea-8762-4f68cff74a4e.png)
