### PR TITLE
Fix implicit grant Spotify.Web.Auth example in docs

### DIFF
--- a/SpotifyAPI.Docs/docs/implicit_grant.md
+++ b/SpotifyAPI.Docs/docs/implicit_grant.md
@@ -88,16 +88,16 @@ public static async Task Main()
   _server = new EmbedIOAuthServer(new Uri("http://localhost:5000/callback"), 5000);
   await _server.Start();
 
-  _server.ImplictGrantReceived += OnImplictGrantReceived;
+  _server.ImplictGrantReceived += OnImplicitGrantReceived;
 
-  var request = new LoginRequest(_server.BaseUri, "ClientId", LoginRequest.ResponseType.Code)
+  var request = new LoginRequest(_server.BaseUri, "ClientId", LoginRequest.ResponseType.Token)
   {
     Scope = new List<string> { Scopes.UserReadEmail }
   };
-  BrowserUtil.Open(uri);
+  BrowserUtil.Open(request.ToUri());
 }
 
-private static async Task OnImplictGrantReceived(object sender, ImplictGrantResponse response)
+private static async Task OnImplicitGrantReceived(object sender, ImplictGrantResponse response)
 {
   await _server.Stop();
   var spotify = new SpotifyClient(response.AccessToken);


### PR DESCRIPTION
Hi! 

Had to implement implicit grant auth flow today in my CLI app, tried to use the new EmbedIOAuthServer. Found out that the example in the docs is not quite correct (wrong ResponseType, unresolved reference and, while we're at it, a typo). 

Fixed it. Compiles and works properly (tested). The most critical part is the OAuth response type: it should be `Token`, not `Code`.

Hope that'll save some headaches for future developers :D 
Thanks for the useful library :)

P.S. I actually had to add a delay at the end of Main() to prevent the app from stopping before the request gets a chance to be processed, but decided that example's full completeness is not quite important here. You may want to add that as well:
```csharp
  // Prevent the app from terminating, just for this example's completeness
  await Task.Delay(60000);
```