### PR TITLE
Type in client credentials docs

### DIFF
--- a/SpotifyAPI.Docs/docs/client_credentials.md
+++ b/SpotifyAPI.Docs/docs/client_credentials.md
@@ -33,7 +33,7 @@ public static async Task Main()
 {
   var config = SpotifyClientConfig
     .CreateDefault()
-    .WithAuthenticator(new CredentialsAuthenticator("CLIENT_ID", "CLIENT_SECRET"));
+    .WithAuthenticator(new ClientCredentialsAuthenticator("CLIENT_ID", "CLIENT_SECRET"));
 
   var spotify = new SpotifyClient(config);
 }


### PR DESCRIPTION
Noticed a type in docs. 
```SpotifyAPI-NET/SpotifyAPI.Web/Authenticators/``` folder contains only ```ClientCredentialsAuthenticator``` class