### PR TITLE
Adding Endpoint to get a User's Queue

### DIFF
--- a/SpotifyAPI.Web/Clients/Interfaces/IPlayerClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPlayerClient.cs
@@ -204,5 +204,14 @@ namespace SpotifyAPI.Web
     /// </remarks>
     /// <returns></returns>
     Task<bool> AddToQueue(PlayerAddToQueueRequest request);
+
+    /// <summary>
+    /// Get the list of objects that make up the user's queue.
+    /// </summary>
+    /// <remarks>
+    /// https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue
+    /// </remarks>
+    /// <returns></returns>
+    Task<QueueResponse> GetQueue();
   }
 }

--- a/SpotifyAPI.Web/Clients/PlayerClient.cs
+++ b/SpotifyAPI.Web/Clients/PlayerClient.cs
@@ -17,6 +17,11 @@ namespace SpotifyAPI.Web
       return statusCode == HttpStatusCode.NoContent;
     }
 
+    public Task<QueueResponse> GetQueue()
+    {
+      return API.Get<QueueResponse>(URLs.PlayerQueue());
+    }
+
     public Task<DeviceResponse> GetAvailableDevices()
     {
       return API.Get<DeviceResponse>(URLs.PlayerDevices());

--- a/SpotifyAPI.Web/Models/Response/QueueResponse.cs
+++ b/SpotifyAPI.Web/Models/Response/QueueResponse.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace SpotifyAPI.Web
 {
   public class QueueResponse
   {
-    public FullTrack CurrentlyPlaying { get; set; } = default!;
-    public List<FullTrack> Queue { get; set; } = default!;
+    [JsonConverter(typeof(PlayableItemConverter))]
+    public IPlayableItem CurrentlyPlaying { get; set; } = default!;
+    [JsonProperty(ItemConverterType = typeof(PlayableItemConverter))]
+    public List<IPlayableItem> Queue { get; set; } = default!;
   }
 }
 

--- a/SpotifyAPI.Web/Models/Response/QueueResponse.cs
+++ b/SpotifyAPI.Web/Models/Response/QueueResponse.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web
+{
+  public class QueueResponse
+  {
+    public FullTrack CurrentlyPlaying { get; set; } = default!;
+    public List<FullTrack> Queue { get; set; } = default!;
+  }
+}
+


### PR DESCRIPTION
Spotify now allows getting a user's queue.

The response is very simple, just full track objects.

https://developer.spotify.com/documentation/web-api/reference/#/operations/get-the-users-currently-playing-track

Fixes: #806 