### PR TITLE
feat: allow to pass cancellation token to requests

### DIFF
--- a/SpotifyAPI.Web.Tests/Clients/BrowseClientTest.cs
+++ b/SpotifyAPI.Web.Tests/Clients/BrowseClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -19,7 +20,8 @@ namespace SpotifyAPI.Web.Tests
       await client.GetRecommendationGenres();
 
       api.Verify(a => a.Get<RecommendationGenresResponse>(
-        It.Is<Uri>((uri) => uri.ToString().Contains("recommendations/available-genre-seeds"))
+        It.Is<Uri>((uri) => uri.ToString().Contains("recommendations/available-genre-seeds")),
+        It.IsAny<CancellationToken>()
       ));
     }
   }

--- a/SpotifyAPI.Web.Tests/Clients/FollowClientTest.cs
+++ b/SpotifyAPI.Web.Tests/Clients/FollowClientTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -20,7 +21,8 @@ namespace SpotifyAPI.Web.Tests
 
       api.Verify(a => a.Get<FollowedArtistsResponse>(
         SpotifyUrls.CurrentUserFollower(),
-        It.Is<Dictionary<string, string>>(val => val.ContainsKey("type"))
+        It.Is<Dictionary<string, string>>(val => val.ContainsKey("type")),
+        It.IsAny<CancellationToken>()
       ));
     }
   }

--- a/SpotifyAPI.Web.Tests/Clients/SpotifyClientTest.cs
+++ b/SpotifyAPI.Web.Tests/Clients/SpotifyClientTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using SpotifyAPI.Web.Http;
+using System.Threading;
 
 namespace SpotifyAPI.Web.Tests
 {
@@ -26,7 +27,7 @@ namespace SpotifyAPI.Web.Tests
       };
 
       await spotify.NextPage(response.Albums);
-      api.Verify(a => a.Get<SearchResponse>(new System.Uri("https://next-url")), Times.Once);
+      api.Verify(a => a.Get<SearchResponse>(new System.Uri("https://next-url"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -42,7 +43,7 @@ namespace SpotifyAPI.Web.Tests
       };
 
       await spotify.NextPage(response);
-      api.Verify(a => a.Get<CursorPaging<PlayHistoryItem>>(new System.Uri("https://next-url")), Times.Once);
+      api.Verify(a => a.Get<CursorPaging<PlayHistoryItem>>(new System.Uri("https://next-url"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -58,7 +59,7 @@ namespace SpotifyAPI.Web.Tests
       };
 
       await spotify.NextPage(response);
-      api.Verify(a => a.Get<Paging<PlayHistoryItem>>(new System.Uri("https://next-url")), Times.Once);
+      api.Verify(a => a.Get<Paging<PlayHistoryItem>>(new System.Uri("https://next-url"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -74,7 +75,7 @@ namespace SpotifyAPI.Web.Tests
       };
 
       await spotify.PreviousPage(response);
-      api.Verify(a => a.Get<Paging<PlayHistoryItem>>(new System.Uri("https://previous-url")), Times.Once);
+      api.Verify(a => a.Get<Paging<PlayHistoryItem>>(new System.Uri("https://previous-url"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -90,7 +91,7 @@ namespace SpotifyAPI.Web.Tests
       };
 
       await spotify.PreviousPage(response);
-      api.Verify(a => a.Get<SearchResponse>(new System.Uri("https://previous-url")), Times.Once);
+      api.Verify(a => a.Get<SearchResponse>(new System.Uri("https://previous-url"), It.IsAny<CancellationToken>()), Times.Once);
     }
   }
 }

--- a/SpotifyAPI.Web.Tests/Clients/UserProfileClientTest.cs
+++ b/SpotifyAPI.Web.Tests/Clients/UserProfileClientTest.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -16,7 +17,7 @@ namespace SpotifyAPI.Web
 
       await client.Current();
 
-      api.Verify(a => a.Get<PrivateUser>(SpotifyUrls.Me()), Times.Once);
+      api.Verify(a => a.Get<PrivateUser>(SpotifyUrls.Me(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -28,7 +29,7 @@ namespace SpotifyAPI.Web
 
       await client.Get(userId);
 
-      api.Verify(a => a.Get<PublicUser>(SpotifyUrls.User(userId)), Times.Once);
+      api.Verify(a => a.Get<PublicUser>(SpotifyUrls.User(userId), It.IsAny<CancellationToken>()), Times.Once);
     }
   }
 }

--- a/SpotifyAPI.Web.Tests/RetryHandlers/SimpleRetryHandlerTest.cs
+++ b/SpotifyAPI.Web.Tests/RetryHandlers/SimpleRetryHandlerTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -21,7 +22,7 @@ namespace SpotifyAPI.Web
       });
 
       var retryCalled = 0;
-      setup.Retry = (IRequest request) =>
+      setup.Retry = (IRequest request, CancellationToken ct) =>
       {
         retryCalled++;
         return Task.FromResult(setup.Response.Object);
@@ -50,7 +51,7 @@ namespace SpotifyAPI.Web
       });
 
       var retryCalled = 0;
-      setup.Retry = (IRequest request) =>
+      setup.Retry = (IRequest request, CancellationToken ct) =>
       {
         retryCalled++;
         return Task.FromResult(setup.Response.Object);
@@ -81,7 +82,7 @@ namespace SpotifyAPI.Web
       successResponse.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.OK);
 
       var retryCalled = 0;
-      setup.Retry = (request) =>
+      setup.Retry = (request, ct) =>
       {
         retryCalled++;
         return Task.FromResult(successResponse.Object);
@@ -111,7 +112,7 @@ namespace SpotifyAPI.Web
       successResponse.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.OK);
 
       var retryCalled = 0;
-      setup.Retry = (IRequest request) =>
+      setup.Retry = (IRequest request, CancellationToken ct) =>
       {
         retryCalled++;
         return Task.FromResult(successResponse.Object);
@@ -136,7 +137,7 @@ namespace SpotifyAPI.Web
       setup.Response.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.BadGateway);
 
       var retryCalled = 0;
-      setup.Retry = (request) =>
+      setup.Retry = (request, ct) =>
       {
         retryCalled++;
         return Task.FromResult(setup.Response.Object);
@@ -162,7 +163,7 @@ namespace SpotifyAPI.Web
       setup.Response.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.OK);
 
       var retryCalled = 0;
-      setup.Retry = (request) =>
+      setup.Retry = (request, ct) =>
       {
         retryCalled++;
         return Task.FromResult(setup.Response.Object);

--- a/SpotifyAPI.Web/Clients/AlbumsClient.cs
+++ b/SpotifyAPI.Web/Clients/AlbumsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,41 +9,41 @@ namespace SpotifyAPI.Web
   {
     public AlbumsClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<FullAlbum> Get(string albumId)
+    public Task<FullAlbum> Get(string albumId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
 
-      return API.Get<FullAlbum>(URLs.Album(albumId));
+      return API.Get<FullAlbum>(URLs.Album(albumId),cancel);
     }
 
-    public Task<FullAlbum> Get(string albumId, AlbumRequest request)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<FullAlbum>(URLs.Album(albumId), request.BuildQueryParams());
-    }
-
-    public Task<AlbumsResponse> GetSeveral(AlbumsRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<AlbumsResponse>(URLs.Albums(), request.BuildQueryParams());
-    }
-
-    public Task<Paging<SimpleTrack>> GetTracks(string albumId)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
-
-      return API.Get<Paging<SimpleTrack>>(URLs.AlbumTracks(albumId));
-    }
-
-    public Task<Paging<SimpleTrack>> GetTracks(string albumId, AlbumTracksRequest request)
+    public Task<FullAlbum> Get(string albumId, AlbumRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SimpleTrack>>(URLs.AlbumTracks(albumId), request.BuildQueryParams());
+      return API.Get<FullAlbum>(URLs.Album(albumId), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<AlbumsResponse> GetSeveral(AlbumsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<AlbumsResponse>(URLs.Albums(), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<Paging<SimpleTrack>> GetTracks(string albumId, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
+
+      return API.Get<Paging<SimpleTrack>>(URLs.AlbumTracks(albumId), cancel);
+    }
+
+    public Task<Paging<SimpleTrack>> GetTracks(string albumId, AlbumTracksRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(albumId, nameof(albumId));
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<Paging<SimpleTrack>>(URLs.AlbumTracks(albumId), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/ArtistsClient.cs
+++ b/SpotifyAPI.Web/Clients/ArtistsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,48 +9,48 @@ namespace SpotifyAPI.Web
   {
     public ArtistsClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<FullArtist> Get(string artistId)
+    public Task<FullArtist> Get(string artistId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
 
-      return API.Get<FullArtist>(URLs.Artist(artistId));
+      return API.Get<FullArtist>(URLs.Artist(artistId), cancel);
     }
 
-    public Task<Paging<SimpleAlbum>> GetAlbums(string artistId)
+    public Task<Paging<SimpleAlbum>> GetAlbums(string artistId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
 
-      return API.Get<Paging<SimpleAlbum>>(URLs.ArtistAlbums(artistId));
+      return API.Get<Paging<SimpleAlbum>>(URLs.ArtistAlbums(artistId), cancel);
     }
 
-    public Task<Paging<SimpleAlbum>> GetAlbums(string artistId, ArtistsAlbumsRequest request)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<Paging<SimpleAlbum>>(URLs.ArtistAlbums(artistId), request.BuildQueryParams());
-    }
-
-    public Task<ArtistsRelatedArtistsResponse> GetRelatedArtists(string artistId)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
-
-      return API.Get<ArtistsRelatedArtistsResponse>(URLs.ArtistRelatedArtists(artistId));
-    }
-
-    public Task<ArtistsResponse> GetSeveral(ArtistsRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<ArtistsResponse>(URLs.Artists(), request.BuildQueryParams());
-    }
-
-    public Task<ArtistsTopTracksResponse> GetTopTracks(string artistId, ArtistsTopTracksRequest request)
+    public Task<Paging<SimpleAlbum>> GetAlbums(string artistId, ArtistsAlbumsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<ArtistsTopTracksResponse>(URLs.ArtistTopTracks(artistId), request.BuildQueryParams());
+      return API.Get<Paging<SimpleAlbum>>(URLs.ArtistAlbums(artistId), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<ArtistsRelatedArtistsResponse> GetRelatedArtists(string artistId, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
+
+      return API.Get<ArtistsRelatedArtistsResponse>(URLs.ArtistRelatedArtists(artistId), cancel);
+    }
+
+    public Task<ArtistsResponse> GetSeveral(ArtistsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<ArtistsResponse>(URLs.Artists(), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<ArtistsTopTracksResponse> GetTopTracks(string artistId, ArtistsTopTracksRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(artistId, nameof(artistId));
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<ArtistsTopTracksResponse>(URLs.ArtistTopTracks(artistId), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/BrowseClient.cs
+++ b/SpotifyAPI.Web/Clients/BrowseClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -9,82 +10,82 @@ namespace SpotifyAPI.Web
   {
     public BrowseClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<CategoriesResponse> GetCategories()
+    public Task<CategoriesResponse> GetCategories(CancellationToken cancel = default)
     {
-      return API.Get<CategoriesResponse>(URLs.Categories());
+      return API.Get<CategoriesResponse>(URLs.Categories(), cancel);
     }
 
-    public Task<CategoriesResponse> GetCategories(CategoriesRequest request)
+    public Task<CategoriesResponse> GetCategories(CategoriesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<CategoriesResponse>(URLs.Categories(), request.BuildQueryParams());
+      return API.Get<CategoriesResponse>(URLs.Categories(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<Category> GetCategory(string categoryId)
+    public Task<Category> GetCategory(string categoryId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
 
-      return API.Get<Category>(URLs.Category(categoryId));
+      return API.Get<Category>(URLs.Category(categoryId), cancel);
     }
 
-    public Task<Category> GetCategory(string categoryId, CategoryRequest request)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<Category>(URLs.Category(categoryId), request.BuildQueryParams());
-    }
-
-    public Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
-
-      return API.Get<CategoryPlaylistsResponse>(URLs.CategoryPlaylists(categoryId));
-    }
-
-    public Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CategoriesPlaylistsRequest request)
+    public Task<Category> GetCategory(string categoryId, CategoryRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<CategoryPlaylistsResponse>(URLs.CategoryPlaylists(categoryId), request.BuildQueryParams());
+      return API.Get<Category>(URLs.Category(categoryId), request.BuildQueryParams(), cancel);
     }
 
-    public Task<RecommendationsResponse> GetRecommendations(RecommendationsRequest request)
+    public Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
+
+      return API.Get<CategoryPlaylistsResponse>(URLs.CategoryPlaylists(categoryId), cancel);
+    }
+
+    public Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CategoriesPlaylistsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(categoryId, nameof(categoryId));
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<CategoryPlaylistsResponse>(URLs.CategoryPlaylists(categoryId), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<RecommendationsResponse> GetRecommendations(RecommendationsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<RecommendationsResponse>(URLs.Recommendations(), request.BuildQueryParams());
+      return API.Get<RecommendationsResponse>(URLs.Recommendations(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<RecommendationGenresResponse> GetRecommendationGenres()
+    public Task<RecommendationGenresResponse> GetRecommendationGenres(CancellationToken cancel = default)
     {
-      return API.Get<RecommendationGenresResponse>(URLs.RecommendationGenres());
+      return API.Get<RecommendationGenresResponse>(URLs.RecommendationGenres(), cancel);
     }
 
-    public Task<NewReleasesResponse> GetNewReleases()
+    public Task<NewReleasesResponse> GetNewReleases(CancellationToken cancel = default)
     {
-      return API.Get<NewReleasesResponse>(URLs.NewReleases());
+      return API.Get<NewReleasesResponse>(URLs.NewReleases(), cancel);
     }
 
-    public Task<NewReleasesResponse> GetNewReleases(NewReleasesRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<NewReleasesResponse>(URLs.NewReleases(), request.BuildQueryParams());
-    }
-
-    public Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists()
-    {
-      return API.Get<FeaturedPlaylistsResponse>(URLs.FeaturedPlaylists());
-    }
-
-    public Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(FeaturedPlaylistsRequest request)
+    public Task<NewReleasesResponse> GetNewReleases(NewReleasesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<FeaturedPlaylistsResponse>(URLs.FeaturedPlaylists(), request.BuildQueryParams());
+      return API.Get<NewReleasesResponse>(URLs.NewReleases(), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(CancellationToken cancel = default)
+    {
+      return API.Get<FeaturedPlaylistsResponse>(URLs.FeaturedPlaylists(), cancel);
+    }
+
+    public Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(FeaturedPlaylistsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<FeaturedPlaylistsResponse>(URLs.FeaturedPlaylists(), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/EpisodesClient.cs
+++ b/SpotifyAPI.Web/Clients/EpisodesClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,26 +9,26 @@ namespace SpotifyAPI.Web
   {
     public EpisodesClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<FullEpisode> Get(string episodeId)
+    public Task<FullEpisode> Get(string episodeId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(episodeId, nameof(episodeId));
 
-      return API.Get<FullEpisode>(URLs.Episode(episodeId));
+      return API.Get<FullEpisode>(URLs.Episode(episodeId), cancel);
     }
 
-    public Task<FullEpisode> Get(string episodeId, EpisodeRequest request)
+    public Task<FullEpisode> Get(string episodeId, EpisodeRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(episodeId, nameof(episodeId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<FullEpisode>(URLs.Episode(episodeId), request.BuildQueryParams());
+      return API.Get<FullEpisode>(URLs.Episode(episodeId), request.BuildQueryParams(), cancel);
     }
 
-    public Task<EpisodesResponse> GetSeveral(EpisodesRequest request)
+    public Task<EpisodesResponse> GetSeveral(EpisodesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<EpisodesResponse>(URLs.Episodes(), request.BuildQueryParams());
+      return API.Get<EpisodesResponse>(URLs.Episodes(), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/FollowClient.cs
+++ b/SpotifyAPI.Web/Clients/FollowClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
+using System.Threading;
 
 namespace SpotifyAPI.Web
 {
@@ -10,82 +11,82 @@ namespace SpotifyAPI.Web
   {
     public FollowClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<List<bool>> CheckCurrentUser(FollowCheckCurrentUserRequest request)
+    public Task<List<bool>> CheckCurrentUser(FollowCheckCurrentUserRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(URLs.CurrentUserFollowerContains(), request.BuildQueryParams());
+      return API.Get<List<bool>>(URLs.CurrentUserFollowerContains(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<List<bool>> CheckPlaylist(string playlistId, FollowCheckPlaylistRequest request)
+    public Task<List<bool>> CheckPlaylist(string playlistId, FollowCheckPlaylistRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(URLs.PlaylistFollowersContains(playlistId), request.BuildQueryParams());
+      return API.Get<List<bool>>(URLs.PlaylistFollowersContains(playlistId), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> Follow(FollowRequest request)
+    public async Task<bool> Follow(FollowRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
       var statusCode = await API
-        .Put(URLs.CurrentUserFollower(), request.BuildQueryParams(), request.BuildBodyParams())
+        .Put(URLs.CurrentUserFollower(), request.BuildQueryParams(), request.BuildBodyParams(), cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> FollowPlaylist(string playlistId)
+    public async Task<bool> FollowPlaylist(string playlistId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
 
       var statusCode = await API
-        .Put(URLs.PlaylistFollowers(playlistId), null, null)
+        .Put(URLs.PlaylistFollowers(playlistId), null, null, cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> FollowPlaylist(string playlistId, FollowPlaylistRequest request)
+    public async Task<bool> FollowPlaylist(string playlistId, FollowPlaylistRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
       var statusCode = await API
-        .Put(URLs.PlaylistFollowers(playlistId), null, request.BuildBodyParams())
+        .Put(URLs.PlaylistFollowers(playlistId), null, request.BuildBodyParams(), cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public Task<FollowedArtistsResponse> OfCurrentUser()
+    public Task<FollowedArtistsResponse> OfCurrentUser(CancellationToken cancel = default)
     {
       var request = new FollowOfCurrentUserRequest();
 
-      return OfCurrentUser(request);
+      return OfCurrentUser(request, cancel);
     }
 
-    public Task<FollowedArtistsResponse> OfCurrentUser(FollowOfCurrentUserRequest request)
+    public Task<FollowedArtistsResponse> OfCurrentUser(FollowOfCurrentUserRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<FollowedArtistsResponse>(URLs.CurrentUserFollower(), request.BuildQueryParams());
+      return API.Get<FollowedArtistsResponse>(URLs.CurrentUserFollower(), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> Unfollow(UnfollowRequest request)
+    public async Task<bool> Unfollow(UnfollowRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
       var statusCode = await API
-        .Delete(URLs.CurrentUserFollower(), request.BuildQueryParams(), request.BuildBodyParams())
+        .Delete(URLs.CurrentUserFollower(), request.BuildQueryParams(), request.BuildBodyParams(), cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> UnfollowPlaylist(string playlistId)
+    public async Task<bool> UnfollowPlaylist(string playlistId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
 
       var statusCode = await API
-        .Delete(URLs.PlaylistFollowers(playlistId), null, null)
+        .Delete(URLs.PlaylistFollowers(playlistId), null, null, cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }

--- a/SpotifyAPI.Web/Clients/Interfaces/IAlbumsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IAlbumsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -11,45 +12,49 @@ namespace SpotifyAPI.Web
     /// Get Spotify catalog information for multiple albums identified by their Spotify IDs.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-multiple-albums
     /// </remarks>
     /// <returns></returns>
-    Task<AlbumsResponse> GetSeveral(AlbumsRequest request);
+    Task<AlbumsResponse> GetSeveral(AlbumsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single album.
     /// </summary>
     /// <param name="albumId">The Spotify ID of the album.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-album
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullAlbum> Get(string albumId);
+    Task<FullAlbum> Get(string albumId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single album.
     /// </summary>
     /// <param name="albumId">The Spotify ID of the album.</param>
     /// <param name="request">The request-model which contains required and optional parameters</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-album
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullAlbum> Get(string albumId, AlbumRequest request);
+    Task<FullAlbum> Get(string albumId, AlbumRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an album’s tracks.
     /// Optional parameters can be used to limit the number of tracks returned.
     /// </summary>
     /// <param name="albumId">The Spotify ID of the album.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-albums-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleTrack>> GetTracks(string albumId);
+    Task<Paging<SimpleTrack>> GetTracks(string albumId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an album’s tracks.
@@ -57,10 +62,11 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="albumId">The Spotify ID of the album.</param>
     /// <param name="request">The request-model which contains required and optional parameters</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-albums-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleTrack>> GetTracks(string albumId, AlbumTracksRequest request);
+    Task<Paging<SimpleTrack>> GetTracks(string albumId, AlbumTracksRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IArtistsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IArtistsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -14,30 +15,33 @@ namespace SpotifyAPI.Web
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-multiple-artists
     /// </remarks>
     /// <param name="request">The request-model which contains required and optional parameters</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <returns></returns>
-    Task<ArtistsResponse> GetSeveral(ArtistsRequest request);
+    Task<ArtistsResponse> GetSeveral(ArtistsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single artist identified by their unique Spotify ID.
     /// </summary>
     /// <param name="artistId">The Spotify ID of the artist.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-artist
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullArtist> Get(string artistId);
+    Task<FullArtist> Get(string artistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an artist’s albums.
     /// Optional parameters can be specified in the query string to filter and sort the response.
     /// </summary>
     /// <param name="artistId">The Spotify ID for the artist.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-artists-albums
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleAlbum>> GetAlbums(string artistId);
+    Task<Paging<SimpleAlbum>> GetAlbums(string artistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an artist’s albums.
@@ -45,11 +49,12 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="artistId">The Spotify ID for the artist.</param>
     /// <param name="request">The request-model which contains required and optional parameters</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-artists-albums
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleAlbum>> GetAlbums(string artistId, ArtistsAlbumsRequest request);
+    Task<Paging<SimpleAlbum>> GetAlbums(string artistId, ArtistsAlbumsRequest request, CancellationToken cancel = default);
 
 
     /// <summary>
@@ -57,11 +62,12 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="artistId">The Spotify ID for the artist</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-artists-top-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<ArtistsTopTracksResponse> GetTopTracks(string artistId, ArtistsTopTracksRequest request);
+    Task<ArtistsTopTracksResponse> GetTopTracks(string artistId, ArtistsTopTracksRequest request, CancellationToken cancel = default);
 
 
     /// <summary>
@@ -69,10 +75,11 @@ namespace SpotifyAPI.Web
     /// Similarity is based on analysis of the Spotify community’s listening history.
     /// </summary>
     /// <param name="artistId">The Spotify ID for the artist</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-artists-related-artists
     /// </remarks>
     /// <returns></returns>
-    Task<ArtistsRelatedArtistsResponse> GetRelatedArtists(string artistId);
+    Task<ArtistsRelatedArtistsResponse> GetRelatedArtists(string artistId, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IBrowseClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IBrowseClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -10,63 +11,69 @@ namespace SpotifyAPI.Web
     /// <summary>
     /// Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-categories
     /// </remarks>
     /// <returns></returns>
-    Task<CategoriesResponse> GetCategories();
+    Task<CategoriesResponse> GetCategories(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-categories
     /// </remarks>
     /// <returns></returns>
-    Task<CategoriesResponse> GetCategories(CategoriesRequest request);
+    Task<CategoriesResponse> GetCategories(CategoriesRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
     /// </summary>
     /// <param name="categoryId">The Spotify category ID for the category.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-category
     /// </remarks>
     /// <returns></returns>
-    Task<Category> GetCategory(string categoryId);
+    Task<Category> GetCategory(string categoryId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
     /// </summary>
     /// <param name="categoryId">The Spotify category ID for the category.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-category
     /// </remarks>
     /// <returns></returns>
-    Task<Category> GetCategory(string categoryId, CategoryRequest request);
+    Task<Category> GetCategory(string categoryId, CategoryRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of Spotify playlists tagged with a particular category.
     /// </summary>
     /// <param name="categoryId">The Spotify category ID for the category.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-categories-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId);
+    Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of Spotify playlists tagged with a particular category.
     /// </summary>
     /// <param name="categoryId">The Spotify category ID for the category.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-categories-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CategoriesPlaylistsRequest request);
+    Task<CategoryPlaylistsResponse> GetCategoryPlaylists(string categoryId, CategoriesPlaylistsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Recommendations are generated based on the available information for a given seed entity and matched against
@@ -74,57 +81,63 @@ namespace SpotifyAPI.Web
     /// a list of tracks will be returned together with pool size details.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-recommendations
     /// </remarks>
     /// <returns></returns>
-    Task<RecommendationsResponse> GetRecommendations(RecommendationsRequest request);
+    Task<RecommendationsResponse> GetRecommendations(RecommendationsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Retrieve a list of available genres seed parameter values for recommendations.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-recommendation-genres
     /// </remarks>
     /// <returns></returns>
-    Task<RecommendationGenresResponse> GetRecommendationGenres();
+    Task<RecommendationGenresResponse> GetRecommendationGenres(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-new-releases
     /// </remarks>
     /// <returns></returns>
-    Task<NewReleasesResponse> GetNewReleases();
+    Task<NewReleasesResponse> GetNewReleases(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-new-releases
     /// </remarks>
     /// <returns></returns>
-    Task<NewReleasesResponse> GetNewReleases(NewReleasesRequest request);
+    Task<NewReleasesResponse> GetNewReleases(NewReleasesRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of Spotify featured playlists (shown, for example, on a Spotify player’s ‘Browse’ tab).
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-featured-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists();
+    Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of Spotify featured playlists (shown, for example, on a Spotify player’s ‘Browse’ tab).
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-featured-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(FeaturedPlaylistsRequest request);
+    Task<FeaturedPlaylistsResponse> GetFeaturedPlaylists(FeaturedPlaylistsRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IEpisodesClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IEpisodesClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -11,33 +12,36 @@ namespace SpotifyAPI.Web
     /// Get Spotify catalog information for a single episode identified by its unique Spotify ID.
     /// </summary>
     /// <param name="episodeId">The Spotify ID for the episode.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-episode
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullEpisode> Get(string episodeId);
+    Task<FullEpisode> Get(string episodeId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single episode identified by its unique Spotify ID.
     /// </summary>
     /// <param name="episodeId">The Spotify ID for the episode.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-an-episode
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullEpisode> Get(string episodeId, EpisodeRequest request);
+    Task<FullEpisode> Get(string episodeId, EpisodeRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for several episodes based on their Spotify IDs.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-multiple-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<EpisodesResponse> GetSeveral(EpisodesRequest request);
+    Task<EpisodesResponse> GetSeveral(EpisodesRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IFollowClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IFollowClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -12,32 +13,35 @@ namespace SpotifyAPI.Web
     /// Check to see if the current user is following one or more artists or other Spotify users.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-check-current-user-follows
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckCurrentUser(FollowCheckCurrentUserRequest request);
+    Task<List<bool>> CheckCurrentUser(FollowCheckCurrentUserRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Check to see if one or more Spotify users are following a specified playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID of the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-check-if-user-follows-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckPlaylist(string playlistId, FollowCheckPlaylistRequest request);
+    Task<List<bool>> CheckPlaylist(string playlistId, FollowCheckPlaylistRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Add the current user as a follower of one or more artists or other Spotify users.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-follow-artists-users
     /// </remarks>
     /// <returns></returns>
-    Task<bool> Follow(FollowRequest request);
+    Task<bool> Follow(FollowRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Add the current user as a follower of a playlist.
@@ -47,11 +51,12 @@ namespace SpotifyAPI.Web
     /// Any playlist can be followed, regardless of its public/private status,
     /// as long as you know its playlist ID.
     /// </param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-follow-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<bool> FollowPlaylist(string playlistId);
+    Task<bool> FollowPlaylist(string playlistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Add the current user as a follower of a playlist.
@@ -62,49 +67,54 @@ namespace SpotifyAPI.Web
     /// as long as you know its playlist ID.
     /// </param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-follow-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<bool> FollowPlaylist(string playlistId, FollowPlaylistRequest request);
+    Task<bool> FollowPlaylist(string playlistId, FollowPlaylistRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current user’s followed artists.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-followed
     /// </remarks>
     /// <returns></returns>
-    Task<FollowedArtistsResponse> OfCurrentUser();
+    Task<FollowedArtistsResponse> OfCurrentUser(CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current user’s followed artists.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-followed
     /// </remarks>
     /// <returns></returns>
-    Task<FollowedArtistsResponse> OfCurrentUser(FollowOfCurrentUserRequest request);
+    Task<FollowedArtistsResponse> OfCurrentUser(FollowOfCurrentUserRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Remove the current user as a follower of one or more artists or other Spotify users.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-unfollow-artists-users
     /// </remarks>
     /// <returns></returns>
-    Task<bool> Unfollow(UnfollowRequest request);
+    Task<bool> Unfollow(UnfollowRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Remove the current user as a follower of a playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID of the playlist that is to be no longer followed.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <returns></returns>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-unfollow-playlist
     /// </remarks>
-    Task<bool> UnfollowPlaylist(string playlistId);
+    Task<bool> UnfollowPlaylist(string playlistId, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/ILibraryClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/ILibraryClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -13,200 +14,220 @@ namespace SpotifyAPI.Web
     /// Remove one or more albums from the current user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-remove-albums-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> RemoveAlbums(LibraryRemoveAlbumsRequest request);
+    Task<bool> RemoveAlbums(LibraryRemoveAlbumsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Remove one or more tracks from the current user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-remove-tracks-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> RemoveTracks(LibraryRemoveTracksRequest request);
+    Task<bool> RemoveTracks(LibraryRemoveTracksRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Delete one or more shows from current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-remove-shows-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> RemoveShows(LibraryRemoveShowsRequest request);
+    Task<bool> RemoveShows(LibraryRemoveShowsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Delete one or more episodes from current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-episodes-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> RemoveEpisodes(LibraryRemoveEpisodesRequest request);
+    Task<bool> RemoveEpisodes(LibraryRemoveEpisodesRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Save one or more tracks to the current user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-save-tracks-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SaveTracks(LibrarySaveTracksRequest request);
+    Task<bool> SaveTracks(LibrarySaveTracksRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Save one or more albums to the current user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-save-albums-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SaveAlbums(LibrarySaveAlbumsRequest request);
+    Task<bool> SaveAlbums(LibrarySaveAlbumsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Save one or more shows to current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-save-shows-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SaveShows(LibrarySaveShowsRequest request);
+    Task<bool> SaveShows(LibrarySaveShowsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Save one or more episodes to current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference/#endpoint-save-episodes-user
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SaveEpisodes(LibrarySaveEpisodesRequest request);
+    Task<bool> SaveEpisodes(LibrarySaveEpisodesRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Check if one or more tracks is already saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-check-users-saved-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckTracks(LibraryCheckTracksRequest request);
+    Task<List<bool>> CheckTracks(LibraryCheckTracksRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Check if one or more albums is already saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-check-users-saved-albums
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckAlbums(LibraryCheckAlbumsRequest request);
+    Task<List<bool>> CheckAlbums(LibraryCheckAlbumsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Check if one or more shows is already saved in the current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-check-users-saved-shows
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckShows(LibraryCheckShowsRequest request);
+    Task<List<bool>> CheckShows(LibraryCheckShowsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Check if one or more episodes is already saved in the current Spotify user’s library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-users-saved-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<List<bool>> CheckEpisodes(LibraryCheckEpisodesRequest request);
+    Task<List<bool>> CheckEpisodes(LibraryCheckEpisodesRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the songs saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedTrack>> GetTracks();
+    Task<Paging<SavedTrack>> GetTracks(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the songs saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedTrack>> GetTracks(LibraryTracksRequest request);
+    Task<Paging<SavedTrack>> GetTracks(LibraryTracksRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the albums saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-albums
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedAlbum>> GetAlbums();
+    Task<Paging<SavedAlbum>> GetAlbums(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the albums saved in the current Spotify user’s ‘Your Music’ library.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-albums
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedAlbum>> GetAlbums(LibraryAlbumsRequest request);
+    Task<Paging<SavedAlbum>> GetAlbums(LibraryAlbumsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of shows saved in the current Spotify user’s library.
     /// Optional parameters can be used to limit the number of shows returned.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-shows
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedShow>> GetShows();
+    Task<Paging<SavedShow>> GetShows(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of shows saved in the current Spotify user’s library.
     /// Optional parameters can be used to limit the number of shows returned.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-shows
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedShow>> GetShows(LibraryShowsRequest request);
+    Task<Paging<SavedShow>> GetShows(LibraryShowsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of episodes saved in the current Spotify user’s library.
     /// Optional parameters can be used to limit the number of shows returned.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     ///  https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedEpisodes>> GetEpisodes();
+    Task<Paging<SavedEpisodes>> GetEpisodes(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of episodes saved in the current Spotify user’s library.
     /// Optional parameters can be used to limit the number of shows returned.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SavedEpisodes>> GetEpisodes(LibraryEpisodesRequest request);
+    Task<Paging<SavedEpisodes>> GetEpisodes(LibraryEpisodesRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IMarketsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IMarketsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -10,10 +11,11 @@ namespace SpotifyAPI.Web
     /// <summary>
     /// Get the list of markets where Spotify is available.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference/#/operations/get-available-markets
     /// </remarks>
     /// <returns></returns>
-    Task<AvailableMarketsResponse> AvailableMarkets();
+    Task<AvailableMarketsResponse> AvailableMarkets(CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IMarketsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IMarketsClient.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace SpotifyAPI.Web
+{
+  /// <summary>
+  /// Markets Endpoints
+  /// </summary>
+  public interface IMarketsClient
+  {
+    /// <summary>
+    /// Get the list of markets where Spotify is available.
+    /// </summary>
+    /// <remarks>
+    /// https://developer.spotify.com/documentation/web-api/reference/#/operations/get-available-markets
+    /// </remarks>
+    /// <returns></returns>
+    Task<AvailableMarketsResponse> AvailableMarkets();
+  }
+}

--- a/SpotifyAPI.Web/Clients/Interfaces/IOAuthClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IOAuthClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -12,50 +13,55 @@ namespace SpotifyAPI.Web
     /// If the token is expired, simply call the funtion again to get a new token
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
     /// </remarks>
     /// <returns></returns>
-    Task<ClientCredentialsTokenResponse> RequestToken(ClientCredentialsRequest request);
+    Task<ClientCredentialsTokenResponse> RequestToken(ClientCredentialsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Refresh an already received token via Authorization Code Auth
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
     /// </remarks>
     /// <returns></returns>
-    Task<AuthorizationCodeRefreshResponse> RequestToken(AuthorizationCodeRefreshRequest request);
+    Task<AuthorizationCodeRefreshResponse> RequestToken(AuthorizationCodeRefreshRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Reequest an initial token via Authorization Code Auth
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
     /// </remarks>
     /// <returns></returns>
-    Task<AuthorizationCodeTokenResponse> RequestToken(AuthorizationCodeTokenRequest request);
+    Task<AuthorizationCodeTokenResponse> RequestToken(AuthorizationCodeTokenRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Swaps out a received code with a access token using a remote server
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
     /// </remarks>
     /// <returns></returns>
-    Task<AuthorizationCodeTokenResponse> RequestToken(TokenSwapTokenRequest request);
+    Task<AuthorizationCodeTokenResponse> RequestToken(TokenSwapTokenRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Gets a refreshed access token using an already received refresh token using a remote server
     /// </summary>
     /// <param name="request"></param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
     /// </remarks>
     /// <returns></returns>
-    Task<AuthorizationCodeRefreshResponse> RequestToken(TokenSwapRefreshRequest request);
+    Task<AuthorizationCodeRefreshResponse> RequestToken(TokenSwapRefreshRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IPaginator.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPaginator.cs
@@ -17,9 +17,10 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="firstPage">The first page. Will be included in the result list!</param>
     /// <param name="connector">An API Connector to make requests to spotify</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <typeparam name="T">Paging Type</typeparam>
     /// <returns>A list containing all pages, including the firstPage</returns>
-    Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector);
+    Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector, CancellationToken cancel = default);
 
     /// <summary>
     /// Fetches all pages and returns them grouped in a list.
@@ -30,13 +31,15 @@ namespace SpotifyAPI.Web
     /// <param name="firstPage">The first page. Will be included in the result list!</param>
     /// <param name="mapper">A function which returns the actual paging object in another response object</param>
     /// <param name="connector">An API Connector to make requests to spotify</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <typeparam name="T">Paging Type</typeparam>
     /// <typeparam name="TNext">Outer response Type</typeparam>
     /// <returns>A list containing all pages, including the firstPage</returns>
     Task<IList<T>> PaginateAll<T, TNext>(
       IPaginatable<T, TNext> firstPage,
       Func<TNext, IPaginatable<T, TNext>> mapper,
-      IAPIConnector connector
+      IAPIConnector connector,
+      CancellationToken cancel = default
     );
 
     /// <summary>
@@ -44,7 +47,7 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="firstPage">The first page. Will be included in the result list!</param>
     /// <param name="connector">An API Connector to make requests to spotify</param>
-    /// <param name="cancel">A CancellationToken</param>
+    /// <param name="cancel">A cancel</param>
     /// <typeparam name="T">Paging Type</typeparam>
     /// <returns></returns>
     IAsyncEnumerable<T> Paginate<T>(IPaginatable<T> firstPage, IAPIConnector connector, CancellationToken cancel = default);
@@ -58,7 +61,7 @@ namespace SpotifyAPI.Web
     /// <param name="firstPage">The first page. Will be included in the result list!</param>
     /// <param name="mapper">A function which returns the actual paging object in another response object</param>
     /// <param name="connector">An API Connector to make requests to spotify</param>
-    /// <param name="cancel">A CancellationToken</param>
+    /// <param name="cancel">A cancel</param>
     /// <typeparam name="T">Paging Type</typeparam>
     /// <typeparam name="TNext">Outer response Type</typeparam>
     /// <returns></returns>

--- a/SpotifyAPI.Web/Clients/Interfaces/IPersonalizationClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPersonalizationClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -10,39 +11,43 @@ namespace SpotifyAPI.Web
     /// <summary>
     /// Get the current user’s top tracks based on calculated affinity.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<FullTrack>> GetTopTracks();
+    Task<Paging<FullTrack>> GetTopTracks(CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current user’s top tracks based on calculated affinity.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<FullTrack>> GetTopTracks(PersonalizationTopRequest request);
+    Task<Paging<FullTrack>> GetTopTracks(PersonalizationTopRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current user’s top artists based on calculated affinity.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<FullArtist>> GetTopArtists();
+    Task<Paging<FullArtist>> GetTopArtists(CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current user’s top artists based on calculated affinity.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<FullArtist>> GetTopArtists(PersonalizationTopRequest request);
+    Task<Paging<FullArtist>> GetTopArtists(PersonalizationTopRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IPlayerClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPlayerClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -15,194 +16,214 @@ namespace SpotifyAPI.Web
     /// <summary>
     /// Skips to next track in the user’s queue.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-skip-users-playback-to-next-track
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SkipNext();
+    Task<bool> SkipNext(CancellationToken cancel = default);
 
     /// <summary>
     /// Skips to next track in the user’s queue.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-skip-users-playback-to-next-track
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SkipNext(PlayerSkipNextRequest request);
+    Task<bool> SkipNext(PlayerSkipNextRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Set the repeat mode for the user’s playback. Options are repeat-track, repeat-context, and off.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-set-repeat-mode-on-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SetRepeat(PlayerSetRepeatRequest request);
+    Task<bool> SetRepeat(PlayerSetRepeatRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Transfer playback to a new device and determine if it should start playing.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-transfer-a-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> TransferPlayback(PlayerTransferPlaybackRequest request);
+    Task<bool> TransferPlayback(PlayerTransferPlaybackRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get the object currently being played on the user’s Spotify account.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-the-users-currently-playing-track
     /// </remarks>
     /// <returns></returns>
-    Task<CurrentlyPlaying> GetCurrentlyPlaying(PlayerCurrentlyPlayingRequest request);
+    Task<CurrentlyPlaying> GetCurrentlyPlaying(PlayerCurrentlyPlayingRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get information about the user’s current playback state, including track or episode, progress, and active device.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-information-about-the-users-current-playback
     /// </remarks>
     /// <returns></returns>
-    Task<CurrentlyPlayingContext> GetCurrentPlayback();
+    Task<CurrentlyPlayingContext> GetCurrentPlayback(CancellationToken cancel = default);
 
     /// <summary>
     /// Get information about the user’s current playback state, including track or episode, progress, and active device.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-information-about-the-users-current-playback
     /// </remarks>
     /// <returns></returns>
-    Task<CurrentlyPlayingContext> GetCurrentPlayback(PlayerCurrentPlaybackRequest request);
+    Task<CurrentlyPlayingContext> GetCurrentPlayback(PlayerCurrentPlaybackRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Seeks to the given position in the user’s currently playing track.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-seek-to-position-in-currently-playing-track
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SeekTo(PlayerSeekToRequest request);
+    Task<bool> SeekTo(PlayerSeekToRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Skips to previous track in the user’s queue.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-skip-users-playback-to-previous-track
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SkipPrevious();
+    Task<bool> SkipPrevious(CancellationToken cancel = default);
 
     /// <summary>
     /// Skips to previous track in the user’s queue.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-skip-users-playback-to-previous-track
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SkipPrevious(PlayerSkipPreviousRequest request);
+    Task<bool> SkipPrevious(PlayerSkipPreviousRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Start a new context or resume current playback on the user’s active device.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-start-a-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> ResumePlayback();
+    Task<bool> ResumePlayback(CancellationToken cancel = default);
 
     /// <summary>
     /// Start a new context or resume current playback on the user’s active device.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-start-a-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> ResumePlayback(PlayerResumePlaybackRequest request);
+    Task<bool> ResumePlayback(PlayerResumePlaybackRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Pause playback on the user’s account.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-pause-a-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> PausePlayback();
+    Task<bool> PausePlayback(CancellationToken cancel = default);
 
     /// <summary>
     /// Pause playback on the user’s account.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-pause-a-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> PausePlayback(PlayerPausePlaybackRequest request);
+    Task<bool> PausePlayback(PlayerPausePlaybackRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Set the volume for the user’s current playback device.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-set-volume-for-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SetVolume(PlayerVolumeRequest request);
+    Task<bool> SetVolume(PlayerVolumeRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get tracks from the current user’s recently played tracks. Note: Currently doesn’t support podcast episodes.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-recently-played
     /// </remarks>
     /// <returns></returns>
-    Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed();
+    Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(CancellationToken cancel = default);
 
     /// <summary>
     /// Get tracks from the current user’s recently played tracks. Note: Currently doesn’t support podcast episodes.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-recently-played
     /// </remarks>
     /// <returns></returns>
-    Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(PlayerRecentlyPlayedRequest request);
+    Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(PlayerRecentlyPlayedRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get information about a user’s available devices.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-users-available-devices
     /// </remarks>
     /// <returns></returns>
-    Task<DeviceResponse> GetAvailableDevices();
+    Task<DeviceResponse> GetAvailableDevices(CancellationToken cancel = default);
 
     /// <summary>
     /// Toggle shuffle on or off for user’s playback.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-toggle-shuffle-for-users-playback
     /// </remarks>
     /// <returns></returns>
-    Task<bool> SetShuffle(PlayerShuffleRequest request);
+    Task<bool> SetShuffle(PlayerShuffleRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Add an item to the end of the user’s current playback queue.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-add-to-queue
     /// </remarks>
     /// <returns></returns>
-    Task<bool> AddToQueue(PlayerAddToQueueRequest request);
+    Task<bool> AddToQueue(PlayerAddToQueueRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IPlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPlaylistsClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -13,119 +14,130 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-remove-tracks-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<SnapshotResponse> RemoveItems(string playlistId, PlaylistRemoveItemsRequest request);
+    Task<SnapshotResponse> RemoveItems(string playlistId, PlaylistRemoveItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Add one or more items to a user’s playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-add-tracks-to-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<SnapshotResponse> AddItems(string playlistId, PlaylistAddItemsRequest request);
+    Task<SnapshotResponse> AddItems(string playlistId, PlaylistAddItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get full details of the items of a playlist owned by a Spotify user.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-playlists-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId);
+    Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get full details of the items of a playlist owned by a Spotify user.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-playlists-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, PlaylistGetItemsRequest request);
+    Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, PlaylistGetItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Create a playlist for a Spotify user. (The playlist will be empty until you add tracks.)
     /// </summary>
     /// <param name="userId">The user’s Spotify user ID.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-create-playlist
     /// </remarks>
     /// <returns></returns>
-    Task<FullPlaylist> Create(string userId, PlaylistCreateRequest request);
+    Task<FullPlaylist> Create(string userId, PlaylistCreateRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Replace the image used to represent a specific playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="base64JpgData">Base64 encoded JPEG image data, maximum payload size is 256 KB.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-upload-custom-playlist-cover
     /// </remarks>
     /// <returns></returns>
-    Task<bool> UploadCover(string playlistId, string base64JpgData);
+    Task<bool> UploadCover(string playlistId, string base64JpgData, CancellationToken cancel = default);
 
     /// <summary>
     /// Get the current image associated with a specific playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-playlist-cover
     /// </remarks>
     /// <returns></returns>
-    Task<List<Image>> GetCovers(string playlistId);
+    Task<List<Image>> GetCovers(string playlistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the playlists owned or followed by a Spotify user.
     /// </summary>
     /// <param name="userId">The user’s Spotify user ID.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-list-users-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimplePlaylist>> GetUsers(string userId);
+    Task<Paging<SimplePlaylist>> GetUsers(string userId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the playlists owned or followed by a Spotify user.
     /// </summary>
     /// <param name="userId">The user’s Spotify user ID.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-list-users-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimplePlaylist>> GetUsers(string userId, PlaylistGetUsersRequest request);
+    Task<Paging<SimplePlaylist>> GetUsers(string userId, PlaylistGetUsersRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a playlist owned by a Spotify user.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-playlist
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullPlaylist> Get(string playlistId);
+    Task<FullPlaylist> Get(string playlistId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a playlist owned by a Spotify user.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-playlist
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullPlaylist> Get(string playlistId, PlaylistGetRequest request);
+    Task<FullPlaylist> Get(string playlistId, PlaylistGetRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Replace all the items in a playlist, overwriting its existing items.
@@ -133,51 +145,56 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-replace-playlists-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request);
+    Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the playlists owned or followed by the current Spotify user.
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-list-of-current-users-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimplePlaylist>> CurrentUsers();
+    Task<Paging<SimplePlaylist>> CurrentUsers(CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the playlists owned or followed by the current Spotify user.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-list-of-current-users-playlists
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimplePlaylist>> CurrentUsers(PlaylistCurrentUsersRequest request);
+    Task<Paging<SimplePlaylist>> CurrentUsers(PlaylistCurrentUsersRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-change-playlist-details
     /// </remarks>
     /// <returns></returns>
-    Task<bool> ChangeDetails(string playlistId, PlaylistChangeDetailsRequest request);
+    Task<bool> ChangeDetails(string playlistId, PlaylistChangeDetailsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Reorder an item or a group of items in a playlist.
     /// </summary>
     /// <param name="playlistId">The Spotify ID for the playlist.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-playlists-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<SnapshotResponse> ReorderItems(string playlistId, PlaylistReorderItemsRequest request);
+    Task<SnapshotResponse> ReorderItems(string playlistId, PlaylistReorderItemsRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/ISearchClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/ISearchClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -12,10 +13,11 @@ namespace SpotifyAPI.Web
     /// tracks, shows or episodes that match a keyword string.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-search
     /// </remarks>
     /// <returns></returns>
-    Task<SearchResponse> Item(SearchRequest request);
+    Task<SearchResponse> Item(SearchRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IShowsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IShowsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -11,45 +12,49 @@ namespace SpotifyAPI.Web
     /// Get Spotify catalog information for a single show identified by its unique Spotify ID.
     /// </summary>
     /// <param name="showId">The Spotify ID for the show.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-show
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullShow> Get(string showId);
+    Task<FullShow> Get(string showId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single show identified by its unique Spotify ID.
     /// </summary>
     /// <param name="showId">The Spotify ID for the show.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-show
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullShow> Get(string showId, ShowRequest request);
+    Task<FullShow> Get(string showId, ShowRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for several shows based on their Spotify IDs.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-multiple-shows
     /// </remarks>
     /// <returns></returns>
-    Task<ShowsResponse> GetSeveral(ShowsRequest request);
+    Task<ShowsResponse> GetSeveral(ShowsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an show’s episodes.
     /// Optional parameters can be used to limit the number of episodes returned.
     /// </summary>
     /// <param name="showId">The Spotify ID for the show.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-shows-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleEpisode>> GetEpisodes(string showId);
+    Task<Paging<SimpleEpisode>> GetEpisodes(string showId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information about an show’s episodes.
@@ -57,10 +62,11 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="showId">The Spotify ID for the show.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-a-shows-episodes
     /// </remarks>
     /// <returns></returns>
-    Task<Paging<SimpleEpisode>> GetEpisodes(string showId, ShowEpisodesRequest request);
+    Task<Paging<SimpleEpisode>> GetEpisodes(string showId, ShowEpisodesRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/ISpotifyClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/ISpotifyClient.cs
@@ -135,13 +135,13 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="firstPage">A first page, will be included in the output list!</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <returns>An iterable IAsyncEnumerable</returns>
     IAsyncEnumerable<T> Paginate<T>(
       IPaginatable<T> firstPage,
       IPaginator? paginator = default!,
-      CancellationToken cancellationToken = default!
+      CancellationToken cancel = default!
     );
 
     /// <summary>
@@ -154,7 +154,7 @@ namespace SpotifyAPI.Web
     /// <param name="firstPage">A first page, will be included in the output list!</param>
     /// <param name="mapper">A function which maps response objects to the next paging object</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <typeparam name="TNext">The Response-Type</typeparam>
     /// <returns></returns>
@@ -162,7 +162,7 @@ namespace SpotifyAPI.Web
       IPaginatable<T, TNext> firstPage,
       Func<TNext, IPaginatable<T, TNext>> mapper,
       IPaginator? paginator = default!,
-      CancellationToken cancellationToken = default!
+      CancellationToken cancel = default!
     );
 
     public Task<Paging<T>> NextPage<T>(Paging<T> paging);

--- a/SpotifyAPI.Web/Clients/Interfaces/ITracksClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/ITracksClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -11,60 +12,66 @@ namespace SpotifyAPI.Web
     /// Get Spotify catalog information for multiple tracks based on their Spotify IDs.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-several-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<TracksResponse> GetSeveral(TracksRequest request);
+    Task<TracksResponse> GetSeveral(TracksRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a detailed audio analysis for a single track identified by its unique Spotify ID.
     /// </summary>
     /// <param name="trackId">The Spotify ID for the track.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-audio-analysis
     /// </remarks>
     /// <returns></returns>
-    Task<TrackAudioAnalysis> GetAudioAnalysis(string trackId);
+    Task<TrackAudioAnalysis> GetAudioAnalysis(string trackId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get audio feature information for a single track identified by its unique Spotify ID.
     /// </summary>
     /// <param name="trackId">The Spotify ID for the track.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-audio-features
     /// </remarks>
     /// <returns></returns>
-    Task<TrackAudioFeatures> GetAudioFeatures(string trackId);
+    Task<TrackAudioFeatures> GetAudioFeatures(string trackId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single track identified by its unique Spotify ID.
     /// </summary>
     /// <param name="trackId">The Spotify ID for the track.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-track
     /// </remarks>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullTrack> Get(string trackId);
+    Task<FullTrack> Get(string trackId, CancellationToken cancel = default);
 
     /// <summary>
     /// Get Spotify catalog information for a single track identified by its unique Spotify ID.
     /// </summary>
     /// <param name="trackId">The Spotify ID for the track.</param>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <returns></returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<FullTrack> Get(string trackId, TrackRequest request);
+    Task<FullTrack> Get(string trackId, TrackRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get audio features for multiple tracks based on their Spotify IDs.
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-several-audio-features
     /// </remarks>
     /// <returns></returns>
-    Task<TracksAudioFeaturesResponse> GetSeveralAudioFeatures(TracksAudioFeaturesRequest request);
+    Task<TracksAudioFeaturesResponse> GetSeveralAudioFeatures(TracksAudioFeaturesRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/Interfaces/IUserProfileClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IUserProfileClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web
@@ -11,18 +12,21 @@ namespace SpotifyAPI.Web
     /// <summary>
     ///   Get detailed profile information about the current user (including the current user’s username).
     /// </summary>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-current-users-profile
     /// </remarks>
     /// <exception cref="APIUnauthorizedException">Thrown if the client is not authenticated.</exception>
-    Task<PrivateUser> Current();
+    Task<PrivateUser> Current(CancellationToken cancel = default);
 
     /// <summary>
     ///   Get public profile information about a Spotify user.
     /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-profile</remarks>
     /// <exception cref="APIUnauthorizedException">Thrown if the client is not authenticated.</exception>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<PublicUser> Get(string userId);
+    Task<PublicUser> Get(string userId, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/LibraryClient.cs
+++ b/SpotifyAPI.Web/Clients/LibraryClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
+using System.Threading;
 
 namespace SpotifyAPI.Web
 {
@@ -9,143 +10,143 @@ namespace SpotifyAPI.Web
   {
     public LibraryClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<List<bool>> CheckAlbums(LibraryCheckAlbumsRequest request)
+    public Task<List<bool>> CheckAlbums(LibraryCheckAlbumsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(SpotifyUrls.LibraryAlbumsContains(), request.BuildQueryParams());
+      return API.Get<List<bool>>(SpotifyUrls.LibraryAlbumsContains(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<List<bool>> CheckShows(LibraryCheckShowsRequest request)
+    public Task<List<bool>> CheckShows(LibraryCheckShowsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(SpotifyUrls.LibraryShowsContains(), request.BuildQueryParams());
+      return API.Get<List<bool>>(SpotifyUrls.LibraryShowsContains(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<List<bool>> CheckTracks(LibraryCheckTracksRequest request)
+    public Task<List<bool>> CheckTracks(LibraryCheckTracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(SpotifyUrls.LibraryTracksContains(), request.BuildQueryParams());
+      return API.Get<List<bool>>(SpotifyUrls.LibraryTracksContains(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<List<bool>> CheckEpisodes(LibraryCheckEpisodesRequest request)
+    public Task<List<bool>> CheckEpisodes(LibraryCheckEpisodesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<List<bool>>(SpotifyUrls.LibraryEpisodesContains(), request.BuildQueryParams());
+      return API.Get<List<bool>>(SpotifyUrls.LibraryEpisodesContains(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<Paging<SavedAlbum>> GetAlbums()
+    public Task<Paging<SavedAlbum>> GetAlbums(CancellationToken cancel = default)
     {
-      return API.Get<Paging<SavedAlbum>>(SpotifyUrls.LibraryAlbums());
+      return API.Get<Paging<SavedAlbum>>(SpotifyUrls.LibraryAlbums(), cancel);
     }
 
-    public Task<Paging<SavedAlbum>> GetAlbums(LibraryAlbumsRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<Paging<SavedAlbum>>(SpotifyUrls.LibraryAlbums(), request.BuildQueryParams());
-    }
-
-    public Task<Paging<SavedShow>> GetShows()
-    {
-      return API.Get<Paging<SavedShow>>(SpotifyUrls.LibraryShows());
-    }
-
-    public Task<Paging<SavedShow>> GetShows(LibraryShowsRequest request)
+    public Task<Paging<SavedAlbum>> GetAlbums(LibraryAlbumsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SavedShow>>(SpotifyUrls.LibraryShows(), request.BuildQueryParams());
+      return API.Get<Paging<SavedAlbum>>(SpotifyUrls.LibraryAlbums(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<Paging<SavedTrack>> GetTracks()
+    public Task<Paging<SavedShow>> GetShows(CancellationToken cancel = default)
     {
-      return API.Get<Paging<SavedTrack>>(SpotifyUrls.LibraryTracks());
+      return API.Get<Paging<SavedShow>>(SpotifyUrls.LibraryShows(), cancel);
     }
 
-    public Task<Paging<SavedTrack>> GetTracks(LibraryTracksRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<Paging<SavedTrack>>(SpotifyUrls.LibraryTracks(), request.BuildQueryParams());
-    }
-
-    public Task<Paging<SavedEpisodes>> GetEpisodes()
-    {
-      return API.Get<Paging<SavedEpisodes>>(SpotifyUrls.LibraryEpisodes());
-    }
-
-    public Task<Paging<SavedEpisodes>> GetEpisodes(LibraryEpisodesRequest request)
+    public Task<Paging<SavedShow>> GetShows(LibraryShowsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SavedEpisodes>>(SpotifyUrls.LibraryEpisodes(), request.BuildQueryParams());
+      return API.Get<Paging<SavedShow>>(SpotifyUrls.LibraryShows(), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> RemoveAlbums(LibraryRemoveAlbumsRequest request)
+    public Task<Paging<SavedTrack>> GetTracks(CancellationToken cancel = default)
+    {
+      return API.Get<Paging<SavedTrack>>(SpotifyUrls.LibraryTracks(), cancel);
+    }
+
+    public Task<Paging<SavedTrack>> GetTracks(LibraryTracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Delete(SpotifyUrls.LibraryAlbums(), null, request.BuildBodyParams()).ConfigureAwait(false);
+      return API.Get<Paging<SavedTrack>>(SpotifyUrls.LibraryTracks(), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<Paging<SavedEpisodes>> GetEpisodes(CancellationToken cancel = default)
+    {
+      return API.Get<Paging<SavedEpisodes>>(SpotifyUrls.LibraryEpisodes(), cancel);
+    }
+
+    public Task<Paging<SavedEpisodes>> GetEpisodes(LibraryEpisodesRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<Paging<SavedEpisodes>>(SpotifyUrls.LibraryEpisodes(), request.BuildQueryParams(), cancel);
+    }
+
+    public async Task<bool> RemoveAlbums(LibraryRemoveAlbumsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      var statusCode = await API.Delete(SpotifyUrls.LibraryAlbums(), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> RemoveShows(LibraryRemoveShowsRequest request)
+    public async Task<bool> RemoveShows(LibraryRemoveShowsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Delete(SpotifyUrls.LibraryShows(), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Delete(SpotifyUrls.LibraryShows(), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> RemoveTracks(LibraryRemoveTracksRequest request)
+    public async Task<bool> RemoveTracks(LibraryRemoveTracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Delete(SpotifyUrls.LibraryTracks(), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Delete(SpotifyUrls.LibraryTracks(), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> RemoveEpisodes(LibraryRemoveEpisodesRequest request)
+    public async Task<bool> RemoveEpisodes(LibraryRemoveEpisodesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Delete(SpotifyUrls.LibraryEpisodes(), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Delete(SpotifyUrls.LibraryEpisodes(), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> SaveAlbums(LibrarySaveAlbumsRequest request)
+    public async Task<bool> SaveAlbums(LibrarySaveAlbumsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(SpotifyUrls.LibraryAlbums(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(SpotifyUrls.LibraryAlbums(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> SaveShows(LibrarySaveShowsRequest request)
+    public async Task<bool> SaveShows(LibrarySaveShowsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(SpotifyUrls.LibraryShows(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(SpotifyUrls.LibraryShows(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> SaveTracks(LibrarySaveTracksRequest request)
+    public async Task<bool> SaveTracks(LibrarySaveTracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(SpotifyUrls.LibraryTracks(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(SpotifyUrls.LibraryTracks(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public async Task<bool> SaveEpisodes(LibrarySaveEpisodesRequest request)
+    public async Task<bool> SaveEpisodes(LibrarySaveEpisodesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(SpotifyUrls.LibraryEpisodes(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(SpotifyUrls.LibraryEpisodes(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
   }

--- a/SpotifyAPI.Web/Clients/MarketsClient.cs
+++ b/SpotifyAPI.Web/Clients/MarketsClient.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using SpotifyAPI.Web.Http;
+using URLs = SpotifyAPI.Web.SpotifyUrls;
+
+namespace SpotifyAPI.Web
+{
+  public class MarketsClient : APIClient, IMarketsClient
+  {
+    public SearchClient(IAPIConnector apiConnector) : base(apiConnector) { }
+
+    public Task<AvailableMarketsResponse> AvailableMarkets()
+    {
+      return API.Get<AvailableMarketsResponse>(URLs.Markets());
+    }
+  }
+}

--- a/SpotifyAPI.Web/Clients/MarketsClient.cs
+++ b/SpotifyAPI.Web/Clients/MarketsClient.cs
@@ -6,7 +6,7 @@ namespace SpotifyAPI.Web
 {
   public class MarketsClient : APIClient, IMarketsClient
   {
-    public SearchClient(IAPIConnector apiConnector) : base(apiConnector) { }
+    public MarketsClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
     public Task<AvailableMarketsResponse> AvailableMarkets()
     {

--- a/SpotifyAPI.Web/Clients/MarketsClient.cs
+++ b/SpotifyAPI.Web/Clients/MarketsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,9 +9,9 @@ namespace SpotifyAPI.Web
   {
     public MarketsClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<AvailableMarketsResponse> AvailableMarkets()
+    public Task<AvailableMarketsResponse> AvailableMarkets(CancellationToken cancel = default)
     {
-      return API.Get<AvailableMarketsResponse>(URLs.Markets());
+      return API.Get<AvailableMarketsResponse>(URLs.Markets(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/OAuthClient.cs
+++ b/SpotifyAPI.Web/Clients/OAuthClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
+using System.Threading;
 
 namespace SpotifyAPI.Web
 {
@@ -19,26 +20,28 @@ namespace SpotifyAPI.Web
     /// Requests a new token using pkce flow
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
     /// </remarks>
     /// <returns></returns>1
-    public Task<PKCETokenResponse> RequestToken(PKCETokenRequest request)
+    public Task<PKCETokenResponse> RequestToken(PKCETokenRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
     /// Refreshes a token using pkce flow
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
     /// </remarks>
     /// <returns></returns>1
-    public Task<PKCETokenResponse> RequestToken(PKCETokenRefreshRequest request)
+    public Task<PKCETokenResponse> RequestToken(PKCETokenRefreshRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
@@ -46,68 +49,78 @@ namespace SpotifyAPI.Web
     /// If the token is expired, simply call the funtion again to get a new token
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
     /// </remarks>
     /// <returns></returns>1
-    public Task<ClientCredentialsTokenResponse> RequestToken(ClientCredentialsRequest request)
+    public Task<ClientCredentialsTokenResponse> RequestToken(ClientCredentialsRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
     /// Refresh an already received token via Authorization Code Auth
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
     /// </remarks>
     /// <returns></returns>
-    public Task<AuthorizationCodeRefreshResponse> RequestToken(AuthorizationCodeRefreshRequest request)
+    public Task<AuthorizationCodeRefreshResponse> RequestToken(AuthorizationCodeRefreshRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
     /// Request an initial token via Authorization Code Auth
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
     /// </remarks>
     /// <returns></returns>
-    public Task<AuthorizationCodeTokenResponse> RequestToken(AuthorizationCodeTokenRequest request)
+    public Task<AuthorizationCodeTokenResponse> RequestToken(AuthorizationCodeTokenRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
     /// Swaps out a received code with a access token using a remote server
     /// </summary>
     /// <param name="request">The request-model which contains required and optional parameters.</param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
     /// </remarks>
     /// <returns></returns>
-    public Task<AuthorizationCodeTokenResponse> RequestToken(TokenSwapTokenRequest request)
+    public Task<AuthorizationCodeTokenResponse> RequestToken(TokenSwapTokenRequest request, CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
     /// <summary>
     /// Gets a refreshed access token using an already received refresh token using a remote server
     /// </summary>
     /// <param name="request"></param>
+    /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>
     /// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
     /// </remarks>
     /// <returns></returns>
-    public Task<AuthorizationCodeRefreshResponse> RequestToken(TokenSwapRefreshRequest request)
+    public Task<AuthorizationCodeRefreshResponse> RequestToken(
+      TokenSwapRefreshRequest request,
+      CancellationToken cancel = default)
     {
-      return RequestToken(request, API);
+      return RequestToken(request, API, cancel);
     }
 
-    public static Task<PKCETokenResponse> RequestToken(PKCETokenRequest request, IAPIConnector apiConnector)
+    public static Task<PKCETokenResponse> RequestToken(
+      PKCETokenRequest request,
+      IAPIConnector apiConnector,
+      CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
       Ensure.ArgumentNotNull(apiConnector, nameof(apiConnector));
@@ -121,10 +134,13 @@ namespace SpotifyAPI.Web
         new KeyValuePair<string?, string?>("code_verifier", request.CodeVerifier),
       };
 
-      return SendOAuthRequest<PKCETokenResponse>(apiConnector, form, null, null);
+      return SendOAuthRequest<PKCETokenResponse>(apiConnector, form, null, null, cancel);
     }
 
-    public static Task<PKCETokenResponse> RequestToken(PKCETokenRefreshRequest request, IAPIConnector apiConnector)
+    public static Task<PKCETokenResponse> RequestToken(
+      PKCETokenRefreshRequest request,
+      IAPIConnector apiConnector,
+      CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
       Ensure.ArgumentNotNull(apiConnector, nameof(apiConnector));
@@ -136,11 +152,13 @@ namespace SpotifyAPI.Web
         new KeyValuePair<string?, string?>("refresh_token", request.RefreshToken),
       };
 
-      return SendOAuthRequest<PKCETokenResponse>(apiConnector, form, null, null);
+      return SendOAuthRequest<PKCETokenResponse>(apiConnector, form, null, null, cancel);
     }
 
     public static Task<AuthorizationCodeRefreshResponse> RequestToken(
-        TokenSwapRefreshRequest request, IAPIConnector apiConnector
+        TokenSwapRefreshRequest request,
+        IAPIConnector apiConnector,
+        CancellationToken cancel = default
       )
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -152,13 +170,16 @@ namespace SpotifyAPI.Web
       };
 #pragma warning disable CA2000
       return apiConnector.Post<AuthorizationCodeRefreshResponse>(
-        request.RefreshUri, null, new FormUrlEncodedContent(form)
+        request.RefreshUri, null, new FormUrlEncodedContent(form),
+        cancel
       );
 #pragma warning restore CA2000
     }
 
     public static Task<AuthorizationCodeTokenResponse> RequestToken(
-        TokenSwapTokenRequest request, IAPIConnector apiConnector
+        TokenSwapTokenRequest request,
+        IAPIConnector apiConnector,
+        CancellationToken cancel = default
       )
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -171,13 +192,16 @@ namespace SpotifyAPI.Web
 
 #pragma warning disable CA2000
       return apiConnector.Post<AuthorizationCodeTokenResponse>(
-        request.TokenUri, null, new FormUrlEncodedContent(form)
+        request.TokenUri, null, new FormUrlEncodedContent(form),
+        cancel
       );
 #pragma warning restore CA2000
     }
 
     public static Task<ClientCredentialsTokenResponse> RequestToken(
-        ClientCredentialsRequest request, IAPIConnector apiConnector
+        ClientCredentialsRequest request,
+        IAPIConnector apiConnector,
+        CancellationToken cancel = default
       )
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -188,11 +212,13 @@ namespace SpotifyAPI.Web
         new KeyValuePair<string?, string?>("grant_type", "client_credentials")
       };
 
-      return SendOAuthRequest<ClientCredentialsTokenResponse>(apiConnector, form, request.ClientId, request.ClientSecret);
+      return SendOAuthRequest<ClientCredentialsTokenResponse>(apiConnector, form, request.ClientId, request.ClientSecret, cancel);
     }
 
     public static Task<AuthorizationCodeRefreshResponse> RequestToken(
-        AuthorizationCodeRefreshRequest request, IAPIConnector apiConnector
+        AuthorizationCodeRefreshRequest request,
+        IAPIConnector apiConnector,
+        CancellationToken cancel = default
       )
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -204,11 +230,13 @@ namespace SpotifyAPI.Web
         new KeyValuePair<string?, string?>("refresh_token", request.RefreshToken)
       };
 
-      return SendOAuthRequest<AuthorizationCodeRefreshResponse>(apiConnector, form, request.ClientId, request.ClientSecret);
+      return SendOAuthRequest<AuthorizationCodeRefreshResponse>(apiConnector, form, request.ClientId, request.ClientSecret, cancel);
     }
 
     public static Task<AuthorizationCodeTokenResponse> RequestToken(
-        AuthorizationCodeTokenRequest request, IAPIConnector apiConnector
+        AuthorizationCodeTokenRequest request,
+        IAPIConnector apiConnector,
+        CancellationToken cancel = default
       )
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -221,18 +249,19 @@ namespace SpotifyAPI.Web
         new KeyValuePair<string?, string?>("redirect_uri", request.RedirectUri.ToString())
       };
 
-      return SendOAuthRequest<AuthorizationCodeTokenResponse>(apiConnector, form, request.ClientId, request.ClientSecret);
+      return SendOAuthRequest<AuthorizationCodeTokenResponse>(apiConnector, form, request.ClientId, request.ClientSecret, cancel);
     }
 
     private static Task<T> SendOAuthRequest<T>(
       IAPIConnector apiConnector,
       List<KeyValuePair<string?, string?>> form,
       string? clientId,
-      string? clientSecret)
+      string? clientSecret,
+      CancellationToken cancel = default)
     {
       var headers = BuildAuthHeader(clientId, clientSecret);
 #pragma warning disable CA2000
-      return apiConnector.Post<T>(SpotifyUrls.OAuthToken, null, new FormUrlEncodedContent(form), headers);
+      return apiConnector.Post<T>(SpotifyUrls.OAuthToken, null, new FormUrlEncodedContent(form), headers, cancel);
 #pragma warning restore CA2000
     }
 

--- a/SpotifyAPI.Web/Clients/PersonalizationClient.cs
+++ b/SpotifyAPI.Web/Clients/PersonalizationClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,28 +9,28 @@ namespace SpotifyAPI.Web
   {
     public PersonalizationClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<Paging<FullArtist>> GetTopArtists()
+    public Task<Paging<FullArtist>> GetTopArtists(CancellationToken cancel = default)
     {
-      return API.Get<Paging<FullArtist>>(URLs.PersonalizationTop("artists"));
+      return API.Get<Paging<FullArtist>>(URLs.PersonalizationTop("artists"), cancel);
     }
 
-    public Task<Paging<FullArtist>> GetTopArtists(PersonalizationTopRequest request)
+    public Task<Paging<FullArtist>> GetTopArtists(PersonalizationTopRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<FullArtist>>(URLs.PersonalizationTop("artists"), request.BuildQueryParams());
+      return API.Get<Paging<FullArtist>>(URLs.PersonalizationTop("artists"), request.BuildQueryParams(), cancel);
     }
 
-    public Task<Paging<FullTrack>> GetTopTracks()
+    public Task<Paging<FullTrack>> GetTopTracks(CancellationToken cancel = default)
     {
-      return API.Get<Paging<FullTrack>>(URLs.PersonalizationTop("tracks"));
+      return API.Get<Paging<FullTrack>>(URLs.PersonalizationTop("tracks"), cancel);
     }
 
-    public Task<Paging<FullTrack>> GetTopTracks(PersonalizationTopRequest request)
+    public Task<Paging<FullTrack>> GetTopTracks(PersonalizationTopRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<FullTrack>>(URLs.PersonalizationTop("tracks"), request.BuildQueryParams());
+      return API.Get<Paging<FullTrack>>(URLs.PersonalizationTop("tracks"), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/PlayerClient.cs
+++ b/SpotifyAPI.Web/Clients/PlayerClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -9,145 +10,145 @@ namespace SpotifyAPI.Web
   {
     public PlayerClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public async Task<bool> AddToQueue(PlayerAddToQueueRequest request)
+    public async Task<bool> AddToQueue(PlayerAddToQueueRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Post(URLs.PlayerQueue(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Post(URLs.PlayerQueue(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public Task<DeviceResponse> GetAvailableDevices()
+    public Task<DeviceResponse> GetAvailableDevices(CancellationToken cancel = default)
     {
-      return API.Get<DeviceResponse>(URLs.PlayerDevices());
+      return API.Get<DeviceResponse>(URLs.PlayerDevices(), cancel);
     }
 
-    public Task<CurrentlyPlaying> GetCurrentlyPlaying(PlayerCurrentlyPlayingRequest request)
+    public Task<CurrentlyPlaying> GetCurrentlyPlaying(PlayerCurrentlyPlayingRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<CurrentlyPlaying>(URLs.PlayerCurrentlyPlaying(), request.BuildQueryParams());
+      return API.Get<CurrentlyPlaying>(URLs.PlayerCurrentlyPlaying(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<CurrentlyPlayingContext> GetCurrentPlayback()
+    public Task<CurrentlyPlayingContext> GetCurrentPlayback(CancellationToken cancel = default)
     {
-      return API.Get<CurrentlyPlayingContext>(URLs.Player());
+      return API.Get<CurrentlyPlayingContext>(URLs.Player(), cancel);
     }
 
-    public Task<CurrentlyPlayingContext> GetCurrentPlayback(PlayerCurrentPlaybackRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<CurrentlyPlayingContext>(URLs.Player(), request.BuildQueryParams());
-    }
-
-    public Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed()
-    {
-      return API.Get<CursorPaging<PlayHistoryItem>>(URLs.PlayerRecentlyPlayed());
-    }
-
-    public Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(PlayerRecentlyPlayedRequest request)
+    public Task<CurrentlyPlayingContext> GetCurrentPlayback(PlayerCurrentPlaybackRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<CursorPaging<PlayHistoryItem>>(URLs.PlayerRecentlyPlayed(), request.BuildQueryParams());
+      return API.Get<CurrentlyPlayingContext>(URLs.Player(), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> PausePlayback()
+    public Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(CancellationToken cancel = default)
     {
-      var statusCode = await API.Put(URLs.PlayerPause(), null, null).ConfigureAwait(false);
+      return API.Get<CursorPaging<PlayHistoryItem>>(URLs.PlayerRecentlyPlayed(), cancel);
+    }
+
+    public Task<CursorPaging<PlayHistoryItem>> GetRecentlyPlayed(PlayerRecentlyPlayedRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<CursorPaging<PlayHistoryItem>>(URLs.PlayerRecentlyPlayed(), request.BuildQueryParams(), cancel);
+    }
+
+    public async Task<bool> PausePlayback(CancellationToken cancel = default)
+    {
+      var statusCode = await API.Put(URLs.PlayerPause(), null, null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> PausePlayback(PlayerPausePlaybackRequest request)
+    public async Task<bool> PausePlayback(PlayerPausePlaybackRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlayerPause(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerPause(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> ResumePlayback()
+    public async Task<bool> ResumePlayback(CancellationToken cancel = default)
     {
-      var statusCode = await API.Put(URLs.PlayerResume(), null, null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerResume(), null, null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> ResumePlayback(PlayerResumePlaybackRequest request)
+    public async Task<bool> ResumePlayback(PlayerResumePlaybackRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
       var statusCode = await API
-        .Put(URLs.PlayerResume(), request.BuildQueryParams(), request.BuildBodyParams())
+        .Put(URLs.PlayerResume(), request.BuildQueryParams(), request.BuildBodyParams(), cancel)
         .ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SeekTo(PlayerSeekToRequest request)
+    public async Task<bool> SeekTo(PlayerSeekToRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlayerSeek(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerSeek(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SetRepeat(PlayerSetRepeatRequest request)
+    public async Task<bool> SetRepeat(PlayerSetRepeatRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlayerRepeat(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerRepeat(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SetShuffle(PlayerShuffleRequest request)
+    public async Task<bool> SetShuffle(PlayerShuffleRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlayerShuffle(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerShuffle(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SetVolume(PlayerVolumeRequest request)
+    public async Task<bool> SetVolume(PlayerVolumeRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlayerVolume(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlayerVolume(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SkipNext()
+    public async Task<bool> SkipNext(CancellationToken cancel = default)
     {
-      var statusCode = await API.Post(URLs.PlayerNext(), null, null).ConfigureAwait(false);
+      var statusCode = await API.Post(URLs.PlayerNext(), null, null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> SkipNext(PlayerSkipNextRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      var statusCode = await API.Post(URLs.PlayerNext(), request.BuildQueryParams(), null).ConfigureAwait(false);
-      return statusCode == HttpStatusCode.NoContent;
-    }
-
-    public async Task<bool> SkipPrevious()
-    {
-      var statusCode = await API.Post(URLs.PlayerPrevious(), null, null).ConfigureAwait(false);
-      return statusCode == HttpStatusCode.NoContent;
-    }
-
-    public async Task<bool> SkipPrevious(PlayerSkipPreviousRequest request)
+    public async Task<bool> SkipNext(PlayerSkipNextRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Post(URLs.PlayerPrevious(), request.BuildQueryParams(), null).ConfigureAwait(false);
+      var statusCode = await API.Post(URLs.PlayerNext(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
 
-    public async Task<bool> TransferPlayback(PlayerTransferPlaybackRequest request)
+    public async Task<bool> SkipPrevious(CancellationToken cancel = default)
+    {
+      var statusCode = await API.Post(URLs.PlayerPrevious(), null, null, cancel).ConfigureAwait(false);
+      return statusCode == HttpStatusCode.NoContent;
+    }
+
+    public async Task<bool> SkipPrevious(PlayerSkipPreviousRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.Player(), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Post(URLs.PlayerPrevious(), request.BuildQueryParams(), null, cancel).ConfigureAwait(false);
+      return statusCode == HttpStatusCode.NoContent;
+    }
+
+    public async Task<bool> TransferPlayback(PlayerTransferPlaybackRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      var statusCode = await API.Put(URLs.Player(), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.NoContent;
     }
   }

--- a/SpotifyAPI.Web/Clients/PlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/PlaylistsClient.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -10,127 +11,127 @@ namespace SpotifyAPI.Web
   {
     public PlaylistsClient(IAPIConnector connector) : base(connector) { }
 
-    public Task<SnapshotResponse> RemoveItems(string playlistId, PlaylistRemoveItemsRequest request)
+    public Task<SnapshotResponse> RemoveItems(string playlistId, PlaylistRemoveItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Delete<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams());
+      return API.Delete<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel);
     }
 
-    public Task<SnapshotResponse> AddItems(string playlistId, PlaylistAddItemsRequest request)
+    public Task<SnapshotResponse> AddItems(string playlistId, PlaylistAddItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Post<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams());
+      return API.Post<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel);
     }
 
-    public Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId)
+    public Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, CancellationToken cancel = default)
     {
       var request = new PlaylistGetItemsRequest();
 
-      return GetItems(playlistId, request);
+      return GetItems(playlistId, request, cancel);
     }
 
-    public Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, PlaylistGetItemsRequest request)
+    public Task<Paging<PlaylistTrack<IPlayableItem>>> GetItems(string playlistId, PlaylistGetItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<PlaylistTrack<IPlayableItem>>>(URLs.PlaylistTracks(playlistId), request.BuildQueryParams());
+      return API.Get<Paging<PlaylistTrack<IPlayableItem>>>(URLs.PlaylistTracks(playlistId), request.BuildQueryParams(), cancel);
     }
 
-    public Task<FullPlaylist> Create(string userId, PlaylistCreateRequest request)
+    public Task<FullPlaylist> Create(string userId, PlaylistCreateRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(userId, nameof(userId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Post<FullPlaylist>(URLs.UserPlaylists(userId), null, request.BuildBodyParams());
+      return API.Post<FullPlaylist>(URLs.UserPlaylists(userId), null, request.BuildBodyParams(), cancel);
     }
 
-    public async Task<bool> UploadCover(string playlistId, string base64JpgData)
+    public async Task<bool> UploadCover(string playlistId, string base64JpgData, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNullOrEmptyString(base64JpgData, nameof(base64JpgData));
 
-      var statusCode = await API.PutRaw(URLs.PlaylistImages(playlistId), null, base64JpgData).ConfigureAwait(false);
+      var statusCode = await API.PutRaw(URLs.PlaylistImages(playlistId), null, base64JpgData, cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.Accepted;
     }
 
-    public Task<List<Image>> GetCovers(string playlistId)
+    public Task<List<Image>> GetCovers(string playlistId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
 
-      return API.Get<List<Image>>(URLs.PlaylistImages(playlistId));
+      return API.Get<List<Image>>(URLs.PlaylistImages(playlistId), cancel);
     }
 
-    public Task<Paging<SimplePlaylist>> GetUsers(string userId)
+    public Task<Paging<SimplePlaylist>> GetUsers(string userId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(userId, nameof(userId));
 
-      return API.Get<Paging<SimplePlaylist>>(URLs.UserPlaylists(userId));
+      return API.Get<Paging<SimplePlaylist>>(URLs.UserPlaylists(userId), cancel);
     }
 
-    public Task<Paging<SimplePlaylist>> GetUsers(string userId, PlaylistGetUsersRequest request)
+    public Task<Paging<SimplePlaylist>> GetUsers(string userId, PlaylistGetUsersRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(userId, nameof(userId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SimplePlaylist>>(URLs.UserPlaylists(userId), request.BuildQueryParams());
+      return API.Get<Paging<SimplePlaylist>>(URLs.UserPlaylists(userId), request.BuildQueryParams(), cancel);
     }
 
-    public Task<FullPlaylist> Get(string playlistId)
+    public Task<FullPlaylist> Get(string playlistId, CancellationToken cancel = default)
     {
       var request = new PlaylistGetRequest(); // We need some defaults
 
-      return Get(playlistId, request);
+      return Get(playlistId, request, cancel);
     }
 
-    public Task<FullPlaylist> Get(string playlistId, PlaylistGetRequest request)
+    public Task<FullPlaylist> Get(string playlistId, PlaylistGetRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<FullPlaylist>(URLs.Playlist(playlistId), request.BuildQueryParams());
+      return API.Get<FullPlaylist>(URLs.Playlist(playlistId), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request)
+    public async Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.Created;
     }
 
-    public Task<Paging<SimplePlaylist>> CurrentUsers()
+    public Task<Paging<SimplePlaylist>> CurrentUsers(CancellationToken cancel = default)
     {
-      return API.Get<Paging<SimplePlaylist>>(URLs.CurrentUserPlaylists());
+      return API.Get<Paging<SimplePlaylist>>(URLs.CurrentUserPlaylists(), cancel);
     }
 
-    public Task<Paging<SimplePlaylist>> CurrentUsers(PlaylistCurrentUsersRequest request)
+    public Task<Paging<SimplePlaylist>> CurrentUsers(PlaylistCurrentUsersRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SimplePlaylist>>(URLs.CurrentUserPlaylists(), request.BuildQueryParams());
+      return API.Get<Paging<SimplePlaylist>>(URLs.CurrentUserPlaylists(), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> ChangeDetails(string playlistId, PlaylistChangeDetailsRequest request)
+    public async Task<bool> ChangeDetails(string playlistId, PlaylistChangeDetailsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.Playlist(playlistId), null, request.BuildBodyParams()).ConfigureAwait(false);
+      var statusCode = await API.Put(URLs.Playlist(playlistId), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
       return statusCode == HttpStatusCode.OK;
     }
 
-    public Task<SnapshotResponse> ReorderItems(string playlistId, PlaylistReorderItemsRequest request)
+    public Task<SnapshotResponse> ReorderItems(string playlistId, PlaylistReorderItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Put<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams());
+      return API.Put<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/SearchClient.cs
+++ b/SpotifyAPI.Web/Clients/SearchClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,11 +9,11 @@ namespace SpotifyAPI.Web
   {
     public SearchClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<SearchResponse> Item(SearchRequest request)
+    public Task<SearchResponse> Item(SearchRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<SearchResponse>(URLs.Search(), request.BuildQueryParams());
+      return API.Get<SearchResponse>(URLs.Search(), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/ShowsClient.cs
+++ b/SpotifyAPI.Web/Clients/ShowsClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,41 +9,41 @@ namespace SpotifyAPI.Web
   {
     public ShowsClient(IAPIConnector connector) : base(connector) { }
 
-    public Task<FullShow> Get(string showId)
+    public Task<FullShow> Get(string showId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
 
-      return API.Get<FullShow>(URLs.Show(showId));
+      return API.Get<FullShow>(URLs.Show(showId), cancel);
     }
 
-    public Task<FullShow> Get(string showId, ShowRequest request)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<FullShow>(URLs.Show(showId), request.BuildQueryParams());
-    }
-
-    public Task<ShowsResponse> GetSeveral(ShowsRequest request)
-    {
-      Ensure.ArgumentNotNull(request, nameof(request));
-
-      return API.Get<ShowsResponse>(URLs.Shows(), request.BuildQueryParams());
-    }
-
-    public Task<Paging<SimpleEpisode>> GetEpisodes(string showId)
-    {
-      Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
-
-      return API.Get<Paging<SimpleEpisode>>(URLs.ShowEpisodes(showId));
-    }
-
-    public Task<Paging<SimpleEpisode>> GetEpisodes(string showId, ShowEpisodesRequest request)
+    public Task<FullShow> Get(string showId, ShowRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<Paging<SimpleEpisode>>(URLs.ShowEpisodes(showId), request.BuildQueryParams());
+      return API.Get<FullShow>(URLs.Show(showId), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<ShowsResponse> GetSeveral(ShowsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<ShowsResponse>(URLs.Shows(), request.BuildQueryParams(), cancel);
+    }
+
+    public Task<Paging<SimpleEpisode>> GetEpisodes(string showId, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
+
+      return API.Get<Paging<SimpleEpisode>>(URLs.ShowEpisodes(showId), cancel);
+    }
+
+    public Task<Paging<SimpleEpisode>> GetEpisodes(string showId, ShowEpisodesRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNullOrEmptyString(showId, nameof(showId));
+      Ensure.ArgumentNotNull(request, nameof(request));
+
+      return API.Get<Paging<SimpleEpisode>>(URLs.ShowEpisodes(showId), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/SimplePaginator.cs
+++ b/SpotifyAPI.Web/Clients/SimplePaginator.cs
@@ -18,7 +18,7 @@ namespace SpotifyAPI.Web
       return Task.FromResult(true);
     }
 
-    public async Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector)
+    public async Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(firstPage, nameof(firstPage));
       Ensure.ArgumentNotNull(connector, nameof(connector));
@@ -31,7 +31,7 @@ namespace SpotifyAPI.Web
       }
       while (page.Next != null && await ShouldContinue(results, page).ConfigureAwait(false))
       {
-        page = await connector.Get<Paging<T>>(new Uri(page.Next, UriKind.Absolute)).ConfigureAwait(false);
+        page = await connector.Get<Paging<T>>(new Uri(page.Next, UriKind.Absolute), cancel).ConfigureAwait(false);
         if (page.Items != null)
         {
           results.AddRange(page.Items);
@@ -42,7 +42,8 @@ namespace SpotifyAPI.Web
     }
 
     public async Task<IList<T>> PaginateAll<T, TNext>(
-      IPaginatable<T, TNext> firstPage, Func<TNext, IPaginatable<T, TNext>> mapper, IAPIConnector connector
+      IPaginatable<T, TNext> firstPage, Func<TNext, IPaginatable<T, TNext>> mapper, IAPIConnector connector,
+      CancellationToken cancel = default
     )
     {
       Ensure.ArgumentNotNull(firstPage, nameof(firstPage));
@@ -57,7 +58,7 @@ namespace SpotifyAPI.Web
       }
       while (page.Next != null && await ShouldContinue(results, page).ConfigureAwait(false))
       {
-        var next = await connector.Get<TNext>(new Uri(page.Next, UriKind.Absolute)).ConfigureAwait(false);
+        var next = await connector.Get<TNext>(new Uri(page.Next, UriKind.Absolute), cancel).ConfigureAwait(false);
         page = mapper(next);
         if (page.Items != null)
         {
@@ -87,7 +88,7 @@ namespace SpotifyAPI.Web
       }
       while (page.Next != null)
       {
-        page = await connector.Get<Paging<T>>(new Uri(page.Next, UriKind.Absolute)).ConfigureAwait(false);
+        page = await connector.Get<Paging<T>>(new Uri(page.Next, UriKind.Absolute), cancel).ConfigureAwait(false);
         foreach (var item in page.Items!)
         {
           yield return item;
@@ -116,7 +117,7 @@ namespace SpotifyAPI.Web
       }
       while (page.Next != null)
       {
-        var next = await connector.Get<TNext>(new Uri(page.Next, UriKind.Absolute)).ConfigureAwait(false);
+        var next = await connector.Get<TNext>(new Uri(page.Next, UriKind.Absolute), cancel).ConfigureAwait(false);
         page = mapper(next);
         foreach (var item in page.Items!)
         {

--- a/SpotifyAPI.Web/Clients/SpotifyClient.cs
+++ b/SpotifyAPI.Web/Clients/SpotifyClient.cs
@@ -49,6 +49,7 @@ namespace SpotifyAPI.Web
       Personalization = new PersonalizationClient(_apiConnector);
       Episodes = new EpisodesClient(_apiConnector);
       Library = new LibraryClient(_apiConnector);
+      Markets = new MarketsClient(_apiConnector);
     }
 
     public IPaginator DefaultPaginator { get; }
@@ -78,6 +79,8 @@ namespace SpotifyAPI.Web
     public IEpisodesClient Episodes { get; }
 
     public ILibraryClient Library { get; }
+
+    public IMarketsClient Markets { get; }
 
     public IResponse? LastResponse { get; private set; }
 

--- a/SpotifyAPI.Web/Clients/SpotifyClient.cs
+++ b/SpotifyAPI.Web/Clients/SpotifyClient.cs
@@ -201,16 +201,16 @@ namespace SpotifyAPI.Web
     /// </summary>
     /// <param name="firstPage">A first page, will be included in the output list!</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <returns>An iterable IAsyncEnumerable</returns>
     public IAsyncEnumerable<T> Paginate<T>(
       IPaginatable<T> firstPage,
       IPaginator? paginator = null,
-      CancellationToken cancellationToken = default
+      CancellationToken cancel = default
     )
     {
-      return (paginator ?? DefaultPaginator).Paginate(firstPage, _apiConnector, cancellationToken);
+      return (paginator ?? DefaultPaginator).Paginate(firstPage, _apiConnector, cancel);
     }
 
     /// <summary>
@@ -223,7 +223,7 @@ namespace SpotifyAPI.Web
     /// <param name="firstPage">A first page, will be included in the output list!</param>
     /// <param name="mapper">A function which maps response objects to the next paging object</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <typeparam name="TNext">The Response-Type</typeparam>
     /// <returns></returns>
@@ -231,10 +231,10 @@ namespace SpotifyAPI.Web
       IPaginatable<T, TNext> firstPage,
       Func<TNext, IPaginatable<T, TNext>> mapper,
       IPaginator? paginator = null,
-      CancellationToken cancellationToken = default
+      CancellationToken cancel = default
     )
     {
-      return (paginator ?? DefaultPaginator).Paginate(firstPage, mapper, _apiConnector, cancellationToken);
+      return (paginator ?? DefaultPaginator).Paginate(firstPage, mapper, _apiConnector, cancel);
     }
 
     /// <summary>
@@ -247,7 +247,7 @@ namespace SpotifyAPI.Web
     /// <param name="getFirstPage">A Function to retrive the first page, will be included in the output list!</param>
     /// <param name="mapper">A function which maps response objects to the next paging object</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <typeparam name="TNext">The Response-Type</typeparam>
     /// <returns></returns>
@@ -255,14 +255,14 @@ namespace SpotifyAPI.Web
       Func<Task<IPaginatable<T, TNext>>> getFirstPage,
       Func<TNext, IPaginatable<T, TNext>> mapper,
       IPaginator? paginator = null,
-      [EnumeratorCancellation] CancellationToken cancellationToken = default)
+      [EnumeratorCancellation] CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(getFirstPage, nameof(getFirstPage));
 
       var firstPage = await getFirstPage().ConfigureAwait(false);
       await foreach (var item in (paginator ?? DefaultPaginator)
-        .Paginate(firstPage, mapper, _apiConnector, cancellationToken)
-        .WithCancellation(cancellationToken)
+        .Paginate(firstPage, mapper, _apiConnector, cancel)
+        .WithCancellation(cancel)
       )
       {
         yield return item;
@@ -279,7 +279,7 @@ namespace SpotifyAPI.Web
     /// <param name="firstPageTask">A Task to retrive the first page, will be included in the output list!</param>
     /// <param name="mapper">A function which maps response objects to the next paging object</param>
     /// <param name="paginator">Optional. If not supplied, DefaultPaginator will be used</param>
-    /// <param name="cancellationToken">An optional Cancellation Token</param>
+    /// <param name="cancel">An optional Cancellation Token</param>
     /// <typeparam name="T">The Paging-Type</typeparam>
     /// <typeparam name="TNext">The Response-Type</typeparam>
     /// <returns></returns>
@@ -287,14 +287,14 @@ namespace SpotifyAPI.Web
       Task<IPaginatable<T, TNext>> firstPageTask,
       Func<TNext, IPaginatable<T, TNext>> mapper,
       IPaginator? paginator = null,
-      [EnumeratorCancellation] CancellationToken cancellationToken = default)
+      [EnumeratorCancellation] CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(firstPageTask, nameof(firstPageTask));
 
       var firstPage = await firstPageTask.ConfigureAwait(false);
       await foreach (var item in (paginator ?? DefaultPaginator)
-        .Paginate(firstPage, mapper, _apiConnector, cancellationToken)
-        .WithCancellation(cancellationToken)
+        .Paginate(firstPage, mapper, _apiConnector, cancel)
+        .WithCancellation(cancel)
       )
       {
         yield return item;

--- a/SpotifyAPI.Web/Clients/TracksClient.cs
+++ b/SpotifyAPI.Web/Clients/TracksClient.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 using URLs = SpotifyAPI.Web.SpotifyUrls;
@@ -8,47 +9,47 @@ namespace SpotifyAPI.Web
   {
     public TracksClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<FullTrack> Get(string trackId)
+    public Task<FullTrack> Get(string trackId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(trackId, nameof(trackId));
 
-      return API.Get<FullTrack>(URLs.Track(trackId));
+      return API.Get<FullTrack>(URLs.Track(trackId), cancel);
     }
 
-    public Task<FullTrack> Get(string trackId, TrackRequest request)
+    public Task<FullTrack> Get(string trackId, TrackRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(trackId, nameof(trackId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<FullTrack>(URLs.Track(trackId), request.BuildQueryParams());
+      return API.Get<FullTrack>(URLs.Track(trackId), request.BuildQueryParams(), cancel);
     }
 
-    public Task<TrackAudioAnalysis> GetAudioAnalysis(string trackId)
+    public Task<TrackAudioAnalysis> GetAudioAnalysis(string trackId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(trackId, nameof(trackId));
 
-      return API.Get<TrackAudioAnalysis>(URLs.AudioAnalysis(trackId));
+      return API.Get<TrackAudioAnalysis>(URLs.AudioAnalysis(trackId), cancel);
     }
 
-    public Task<TrackAudioFeatures> GetAudioFeatures(string trackId)
+    public Task<TrackAudioFeatures> GetAudioFeatures(string trackId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(trackId, nameof(trackId));
 
-      return API.Get<TrackAudioFeatures>(URLs.AudioFeatures(trackId));
+      return API.Get<TrackAudioFeatures>(URLs.AudioFeatures(trackId), cancel);
     }
 
-    public Task<TracksResponse> GetSeveral(TracksRequest request)
+    public Task<TracksResponse> GetSeveral(TracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<TracksResponse>(URLs.Tracks(), request.BuildQueryParams());
+      return API.Get<TracksResponse>(URLs.Tracks(), request.BuildQueryParams(), cancel);
     }
 
-    public Task<TracksAudioFeaturesResponse> GetSeveralAudioFeatures(TracksAudioFeaturesRequest request)
+    public Task<TracksAudioFeaturesResponse> GetSeveralAudioFeatures(TracksAudioFeaturesRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<TracksAudioFeaturesResponse>(URLs.AudioFeatures(), request.BuildQueryParams());
+      return API.Get<TracksAudioFeaturesResponse>(URLs.AudioFeatures(), request.BuildQueryParams(), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Clients/UserProfileClient.cs
+++ b/SpotifyAPI.Web/Clients/UserProfileClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SpotifyAPI.Web.Http;
 
@@ -8,16 +9,16 @@ namespace SpotifyAPI.Web
   {
     public UserProfileClient(IAPIConnector apiConnector) : base(apiConnector) { }
 
-    public Task<PrivateUser> Current()
+    public Task<PrivateUser> Current(CancellationToken cancel = default)
     {
-      return API.Get<PrivateUser>(SpotifyUrls.Me());
+      return API.Get<PrivateUser>(SpotifyUrls.Me(), cancel);
     }
 
-    public Task<PublicUser> Get(string userId)
+    public Task<PublicUser> Get(string userId, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(userId, nameof(userId));
 
-      return API.Get<PublicUser>(SpotifyUrls.User(userId));
+      return API.Get<PublicUser>(SpotifyUrls.User(userId), cancel);
     }
   }
 }

--- a/SpotifyAPI.Web/Http/APIConnector.cs
+++ b/SpotifyAPI.Web/Http/APIConnector.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Net;
+using System.Threading;
 
 namespace SpotifyAPI.Web.Http
 {
@@ -36,127 +37,127 @@ namespace SpotifyAPI.Web.Http
       _httpLogger = httpLogger;
     }
 
-    public Task<T> Delete<T>(Uri uri)
+    public Task<T> Delete<T>(Uri uri, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Delete);
+      return SendAPIRequest<T>(uri, HttpMethod.Delete, cancel: cancel);
     }
 
-    public Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters)
+    public Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Delete, parameters);
+      return SendAPIRequest<T>(uri, HttpMethod.Delete, parameters, cancel: cancel);
     }
 
-    public Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Delete, parameters, body);
+      return SendAPIRequest<T>(uri, HttpMethod.Delete, parameters, body, cancel: cancel);
     }
 
-    public async Task<HttpStatusCode> Delete(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public async Task<HttpStatusCode> Delete(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      var response = await SendAPIRequestDetailed(uri, HttpMethod.Delete, parameters, body).ConfigureAwait(false);
+      var response = await SendAPIRequestDetailed(uri, HttpMethod.Delete, parameters, body, cancel: cancel).ConfigureAwait(false);
       return response.StatusCode;
     }
 
-    public Task<T> Get<T>(Uri uri)
+    public Task<T> Get<T>(Uri uri, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Get);
+      return SendAPIRequest<T>(uri, HttpMethod.Get, cancel: cancel);
     }
 
-    public Task<T> Get<T>(Uri uri, IDictionary<string, string>? parameters)
+    public Task<T> Get<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Get, parameters);
+      return SendAPIRequest<T>(uri, HttpMethod.Get, parameters, cancel: cancel);
     }
 
-    public async Task<HttpStatusCode> Get(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public async Task<HttpStatusCode> Get(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      var response = await SendAPIRequestDetailed(uri, HttpMethod.Get, parameters, body).ConfigureAwait(false);
+      var response = await SendAPIRequestDetailed(uri, HttpMethod.Get, parameters, body, cancel: cancel).ConfigureAwait(false);
       return response.StatusCode;
     }
 
-    public Task<T> Post<T>(Uri uri)
+    public Task<T> Post<T>(Uri uri, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Post);
+      return SendAPIRequest<T>(uri, HttpMethod.Post, cancel: cancel);
     }
 
-    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters)
+    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters);
+      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters, cancel: cancel);
     }
 
-    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters, body);
+      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters, body, cancel: cancel);
     }
 
-    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, Dictionary<string, string>? headers)
+    public Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, Dictionary<string, string>? headers, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters, body, headers);
+      return SendAPIRequest<T>(uri, HttpMethod.Post, parameters, body, headers, cancel: cancel);
     }
 
-    public async Task<HttpStatusCode> Post(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public async Task<HttpStatusCode> Post(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      var response = await SendAPIRequestDetailed(uri, HttpMethod.Post, parameters, body).ConfigureAwait(false);
+      var response = await SendAPIRequestDetailed(uri, HttpMethod.Post, parameters, body, cancel: cancel).ConfigureAwait(false);
       return response.StatusCode;
     }
 
-    public Task<T> Put<T>(Uri uri)
+    public Task<T> Put<T>(Uri uri, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Put);
+      return SendAPIRequest<T>(uri, HttpMethod.Put, cancel: cancel);
     }
 
-    public Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters)
+    public Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Put, parameters);
+      return SendAPIRequest<T>(uri, HttpMethod.Put, parameters, cancel: cancel);
     }
 
-    public Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      return SendAPIRequest<T>(uri, HttpMethod.Put, parameters, body);
+      return SendAPIRequest<T>(uri, HttpMethod.Put, parameters, body, cancel: cancel);
     }
 
-    public async Task<HttpStatusCode> Put(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public async Task<HttpStatusCode> Put(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      var response = await SendAPIRequestDetailed(uri, HttpMethod.Put, parameters, body).ConfigureAwait(false);
+      var response = await SendAPIRequestDetailed(uri, HttpMethod.Put, parameters, body, cancel: cancel).ConfigureAwait(false);
       return response.StatusCode;
     }
 
-    public async Task<HttpStatusCode> PutRaw(Uri uri, IDictionary<string, string>? parameters, object? body)
+    public async Task<HttpStatusCode> PutRaw(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(uri, nameof(uri));
 
-      var response = await SendRawRequest(uri, HttpMethod.Put, parameters, body).ConfigureAwait(false);
+      var response = await SendRawRequest(uri, HttpMethod.Put, parameters, body, cancel: cancel).ConfigureAwait(false);
       return response.StatusCode;
     }
 
@@ -187,30 +188,30 @@ namespace SpotifyAPI.Web.Http
       };
     }
 
-    private async Task<IAPIResponse<T>> DoSerializedRequest<T>(IRequest request)
+    private async Task<IAPIResponse<T>> DoSerializedRequest<T>(IRequest request, CancellationToken cancel)
     {
       _jsonSerializer.SerializeRequest(request);
-      var response = await DoRequest(request).ConfigureAwait(false);
+      var response = await DoRequest(request, cancel).ConfigureAwait(false);
       return _jsonSerializer.DeserializeResponse<T>(response);
     }
 
-    private async Task<IResponse> DoRequest(IRequest request)
+    private async Task<IResponse> DoRequest(IRequest request, CancellationToken cancel)
     {
       await ApplyAuthenticator(request).ConfigureAwait(false);
       _httpLogger?.OnRequest(request);
-      IResponse response = await _httpClient.DoRequest(request).ConfigureAwait(false);
+      IResponse response = await _httpClient.DoRequest(request, cancel).ConfigureAwait(false);
       _httpLogger?.OnResponse(response);
       ResponseReceived?.Invoke(this, response);
       if (_retryHandler != null)
       {
-        response = await _retryHandler.HandleRetry(request, response, async (newRequest) =>
+        response = await _retryHandler.HandleRetry(request, response, async (newRequest, ct) =>
         {
           await ApplyAuthenticator(request).ConfigureAwait(false);
-          var newResponse = await _httpClient.DoRequest(request).ConfigureAwait(false);
+          var newResponse = await _httpClient.DoRequest(request, ct).ConfigureAwait(false);
           _httpLogger?.OnResponse(newResponse);
           ResponseReceived?.Invoke(this, response);
           return newResponse;
-        }).ConfigureAwait(false);
+        }, cancel).ConfigureAwait(false);
       }
       ProcessErrors(response);
       return response;
@@ -231,11 +232,12 @@ namespace SpotifyAPI.Web.Http
         HttpMethod method,
         IDictionary<string, string>? parameters = null,
         object? body = null,
-        IDictionary<string, string>? headers = null
+        IDictionary<string, string>? headers = null,
+        CancellationToken cancel = default
       )
     {
       var request = CreateRequest(uri, method, parameters, body, headers);
-      return DoRequest(request);
+      return DoRequest(request, cancel);
     }
 
     public async Task<T> SendAPIRequest<T>(
@@ -243,11 +245,12 @@ namespace SpotifyAPI.Web.Http
         HttpMethod method,
         IDictionary<string, string>? parameters = null,
         object? body = null,
-        IDictionary<string, string>? headers = null
+        IDictionary<string, string>? headers = null,
+        CancellationToken cancel = default
       )
     {
       var request = CreateRequest(uri, method, parameters, body, headers);
-      IAPIResponse<T> apiResponse = await DoSerializedRequest<T>(request).ConfigureAwait(false);
+      IAPIResponse<T> apiResponse = await DoSerializedRequest<T>(request, cancel).ConfigureAwait(false);
       return apiResponse.Body!;
     }
 
@@ -256,11 +259,12 @@ namespace SpotifyAPI.Web.Http
         HttpMethod method,
         IDictionary<string, string>? parameters = null,
         object? body = null,
-        IDictionary<string, string>? headers = null
+        IDictionary<string, string>? headers = null,
+        CancellationToken cancel = default
       )
     {
       var request = CreateRequest(uri, method, parameters, body, headers);
-      var response = await DoSerializedRequest<object>(request).ConfigureAwait(false);
+      var response = await DoSerializedRequest<object>(request, cancel).ConfigureAwait(false);
       return response.Response;
     }
 

--- a/SpotifyAPI.Web/Http/Interfaces/IAPIConnector.cs
+++ b/SpotifyAPI.Web/Http/Interfaces/IAPIConnector.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace SpotifyAPI.Web.Http
 {
@@ -17,34 +18,35 @@ namespace SpotifyAPI.Web.Http
     event EventHandler<IResponse>? ResponseReceived;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<T> Get<T>(Uri uri);
+    Task<T> Get<T>(Uri uri, CancellationToken cancel = default);
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<T> Get<T>(Uri uri, IDictionary<string, string>? parameters);
+    Task<T> Get<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel = default);
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716")]
-    Task<HttpStatusCode> Get(Uri uri, IDictionary<string, string>? parameters, object? body);
+    Task<HttpStatusCode> Get(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
 
-    Task<T> Post<T>(Uri uri);
-    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters);
-    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body);
-    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, Dictionary<string, string>? headers);
-    Task<HttpStatusCode> Post(Uri uri, IDictionary<string, string>? parameters, object? body);
+    Task<T> Post<T>(Uri uri, CancellationToken cancel = default);
+    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel = default);
+    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
+    Task<T> Post<T>(Uri uri, IDictionary<string, string>? parameters, object? body, Dictionary<string, string>? headers, CancellationToken cancel = default);
+    Task<HttpStatusCode> Post(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
 
-    Task<T> Put<T>(Uri uri);
-    Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters);
-    Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, object? body);
-    Task<HttpStatusCode> Put(Uri uri, IDictionary<string, string>? parameters, object? body);
-    Task<HttpStatusCode> PutRaw(Uri uri, IDictionary<string, string>? parameters, object? body);
+    Task<T> Put<T>(Uri uri, CancellationToken cancel = default);
+    Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel = default);
+    Task<T> Put<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
+    Task<HttpStatusCode> Put(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
+    Task<HttpStatusCode> PutRaw(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
 
-    Task<T> Delete<T>(Uri uri);
-    Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters);
-    Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, object? body);
-    Task<HttpStatusCode> Delete(Uri uri, IDictionary<string, string>? parameters, object? body);
+    Task<T> Delete<T>(Uri uri, CancellationToken cancel = default);
+    Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, CancellationToken cancel = default);
+    Task<T> Delete<T>(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
+    Task<HttpStatusCode> Delete(Uri uri, IDictionary<string, string>? parameters, object? body, CancellationToken cancel = default);
 
     Task<T> SendAPIRequest<T>(
       Uri uri, HttpMethod method,
       IDictionary<string, string>? parameters = null,
       object? body = null,
-      IDictionary<string, string>? headers = null);
+      IDictionary<string, string>? headers = null,
+      CancellationToken cancel = default);
 
     void SetRequestTimeout(TimeSpan timeout);
   }

--- a/SpotifyAPI.Web/Http/Interfaces/IHttpClient.cs
+++ b/SpotifyAPI.Web/Http/Interfaces/IHttpClient.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web.Http
 {
   public interface IHTTPClient : IDisposable
   {
-    Task<IResponse> DoRequest(IRequest request);
+    Task<IResponse> DoRequest(IRequest request, CancellationToken cancel = default);
     void SetRequestTimeout(TimeSpan timeout);
   }
 }

--- a/SpotifyAPI.Web/Http/NetHttpClient.cs
+++ b/SpotifyAPI.Web/Http/NetHttpClient.cs
@@ -50,7 +50,11 @@ namespace SpotifyAPI.Web.Http
       // We only support text stuff for now
       using var content = responseMsg.Content;
       var headers = responseMsg.Headers.ToDictionary(header => header.Key, header => header.Value.First());
+#if NETSTANDARD2_1
+      var body = await responseMsg.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
       var body = await responseMsg.Content.ReadAsStringAsync(cancel).ConfigureAwait(false);
+#endif
       var contentType = content.Headers?.ContentType?.MediaType;
 
       return new Response(headers)

--- a/SpotifyAPI.Web/Http/NetHttpClient.cs
+++ b/SpotifyAPI.Web/Http/NetHttpClient.cs
@@ -50,7 +50,7 @@ namespace SpotifyAPI.Web.Http
       // We only support text stuff for now
       using var content = responseMsg.Content;
       var headers = responseMsg.Headers.ToDictionary(header => header.Key, header => header.Value.First());
-      var body = await responseMsg.Content.ReadAsStringAsync().ConfigureAwait(false);
+      var body = await responseMsg.Content.ReadAsStringAsync(cancel).ConfigureAwait(false);
       var contentType = content.Headers?.ContentType?.MediaType;
 
       return new Response(headers)

--- a/SpotifyAPI.Web/Http/NetHttpClient.cs
+++ b/SpotifyAPI.Web/Http/NetHttpClient.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace SpotifyAPI.Web.Http
 {
@@ -30,20 +31,19 @@ namespace SpotifyAPI.Web.Http
       _httpMessageHandler = CreateMessageHandler(proxyConfig);
       _httpClient = new HttpClient(_httpMessageHandler);
     }
-
-    public async Task<IResponse> DoRequest(IRequest request)
+    public async Task<IResponse> DoRequest(IRequest request, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
       using HttpRequestMessage requestMsg = BuildRequestMessage(request);
       var responseMsg = await _httpClient
-              .SendAsync(requestMsg, HttpCompletionOption.ResponseContentRead)
+              .SendAsync(requestMsg, HttpCompletionOption.ResponseContentRead, cancel)
               .ConfigureAwait(false);
 
-      return await BuildResponse(responseMsg).ConfigureAwait(false);
+      return await BuildResponse(responseMsg, cancel).ConfigureAwait(false);
     }
 
-    private static async Task<IResponse> BuildResponse(HttpResponseMessage responseMsg)
+    private static async Task<IResponse> BuildResponse(HttpResponseMessage responseMsg, CancellationToken cancel)
     {
       Ensure.ArgumentNotNull(responseMsg, nameof(responseMsg));
 

--- a/SpotifyAPI.Web/Models/Response/AvailableMarketsResponse.cs
+++ b/SpotifyAPI.Web/Models/Response/AvailableMarketsResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web
+{
+  public class AvailableMarketsResponse
+  {
+    public List<string> Markets { get; set; } = default!;
+  }
+}
+

--- a/SpotifyAPI.Web/RetryHandlers/IRetryHandler.cs
+++ b/SpotifyAPI.Web/RetryHandlers/IRetryHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SpotifyAPI.Web.Http
@@ -8,8 +9,8 @@ namespace SpotifyAPI.Web.Http
   /// </summary>
   public interface IRetryHandler
   {
-    delegate Task<IResponse> RetryFunc(IRequest request);
+    delegate Task<IResponse> RetryFunc(IRequest request, CancellationToken cancel = default);
 
-    Task<IResponse> HandleRetry(IRequest request, IResponse response, RetryFunc retry);
+    Task<IResponse> HandleRetry(IRequest request, IResponse response, RetryFunc retry, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/SpotifyUrls.cs
+++ b/SpotifyAPI.Web/SpotifyUrls.cs
@@ -129,6 +129,8 @@ namespace SpotifyAPI.Web
 
     public static Uri LibraryEpisodesContains() => EUri($"me/episodes/contains");
 
+    public static Uri Markets() => EUri($"markets");
+
     private static Uri EUri(FormattableString path) => new(path.ToString(_provider), UriKind.Relative);
   }
 }


### PR DESCRIPTION
Hello,

to be able to cancel requests when necessary, I added a cancellation token to every request method and passed it down to the actual http client.

Hope this PR is in the interest of you and the other users.

Cheers,
esskar