### PR TITLE
feat: add recommendation engine based on seed entities

### DIFF
--- a/SpotifyAPI.Web/Clients/Interfaces/ITracksClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/ITracksClient.cs
@@ -73,5 +73,13 @@ namespace SpotifyAPI.Web
     /// </remarks>
     /// <returns></returns>
     Task<TracksAudioFeaturesResponse> GetSeveralAudioFeatures(TracksAudioFeaturesRequest request, CancellationToken cancel = default);
+
+    /// <summary>
+    ///  
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancel"></param>
+    /// <returns></returns>
+    Task<TrackRecommendationResponse> GetRecommendationTracks(TrackRecommendationsRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/TracksClient.cs
+++ b/SpotifyAPI.Web/Clients/TracksClient.cs
@@ -38,6 +38,12 @@ namespace SpotifyAPI.Web
       return API.Get<TrackAudioFeatures>(URLs.AudioFeatures(trackId), cancel);
     }
 
+    public Task<TrackRecommendationResponse> GetRecommendationTracks(TrackRecommendationsRequest request, CancellationToken cancel = default)
+    {
+      Ensure.ArgumentNotNull(request, nameof(request));
+      return API.Get<TrackRecommendationResponse>(URLs.TracksRecommendation(), request.BuildQueryParams(), cancel);
+    }
+
     public Task<TracksResponse> GetSeveral(TracksRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
@@ -51,5 +57,7 @@ namespace SpotifyAPI.Web
 
       return API.Get<TracksAudioFeaturesResponse>(URLs.AudioFeatures(), request.BuildQueryParams(), cancel);
     }
+
+
   }
 }

--- a/SpotifyAPI.Web/Models/Request/TrackRecommendationsRequest.cs
+++ b/SpotifyAPI.Web/Models/Request/TrackRecommendationsRequest.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SpotifyAPI.Web
+{
+  public class TrackRecommendationsRequest : RequestParams
+  {
+    public TrackRecommendationsRequest(IList<string> seedIdsArtists, 
+      IList<string> seedIdsGenres, 
+      IList<string> seedIdTracks, int minTempo, int maxTempo)
+    {
+      Ensure.ArgumentNotNullOrEmptyList(seedIdsArtists, nameof(seedIdsArtists));
+      IdsArtists = seedIdsArtists;
+
+      Ensure.ArgumentNotNullOrEmptyList(seedIdsGenres, nameof(seedIdsGenres));
+      IdsGenres = seedIdsGenres;
+
+      Ensure.ArgumentNotNullOrEmptyList(seedIdTracks, nameof(seedIdTracks));
+      IdsTracks = seedIdTracks;
+
+      MinTempo = minTempo;
+      MaxTempo = maxTempo;
+    }
+    
+    [QueryParam("min_tempo")]
+    public int MinTempo { get; }
+
+    [QueryParam("max_tempo")]
+    public int MaxTempo { get; }
+
+    /// <summary>
+    /// A comma-separated list of the Spotify IDs for the artists. Maximum: 100 IDs.
+    /// </summary>
+    /// <value></value>
+    [QueryParam("seed_artists")]
+    public IList<string> IdsArtists { get; }
+
+    /// <summary>
+    /// A comma-separated list of the Spotify IDs for the tracks. Maximum: 100 IDs.
+    /// </summary>
+    /// <value></value>
+    [QueryParam("seed_tracks")]
+    public IList<string> IdsTracks { get; }
+
+    /// <summary>
+    /// A comma-separated list of the Spotify IDs for the tracks. Maximum: 100 IDs.
+    /// </summary>
+    /// <value></value>
+    [QueryParam("seed_genres")]
+    public IList<string> IdsGenres { get; }
+  }
+}

--- a/SpotifyAPI.Web/Models/Response/Seed.cs
+++ b/SpotifyAPI.Web/Models/Response/Seed.cs
@@ -1,0 +1,13 @@
+namespace SpotifyAPI.Web
+{
+  public class Seed
+  {
+    public int AfterFilteringSize { get; set; }
+    public int AfterRelinkingSize { get; set; }
+    public string Href { get; set; }
+    public string Id { get; set; }
+    public int InitialPoolSize { get; set; }
+    public string Type { get; set; }
+
+  }
+}

--- a/SpotifyAPI.Web/Models/Response/TrackRecommendationResponse.cs
+++ b/SpotifyAPI.Web/Models/Response/TrackRecommendationResponse.cs
@@ -1,0 +1,8 @@
+namespace SpotifyAPI.Web
+{
+  public class TrackRecommendationResponse
+  {
+    public Seed[] Seeds { get; set; }
+    public FullTrack[] Tracks { get; set; }
+  }
+}

--- a/SpotifyAPI.Web/SpotifyUrls.cs
+++ b/SpotifyAPI.Web/SpotifyUrls.cs
@@ -59,6 +59,8 @@ namespace SpotifyAPI.Web
 
     public static Uri Track(string trackId) => EUri($"tracks/{trackId}");
 
+    public static Uri TrackRecommendations() => EUri($"recommendations");
+
     public static Uri AudioAnalysis(string trackId) => EUri($"audio-analysis/{trackId}");
 
     public static Uri AudioFeatures(string trackId) => EUri($"audio-features/{trackId}");
@@ -109,6 +111,7 @@ namespace SpotifyAPI.Web
 
     public static Uri PersonalizationTop(string type) => EUri($"me/top/{type}");
 
+
     public static Uri Episode(string episodeId) => EUri($"episodes/{episodeId}");
 
     public static Uri Episodes() => EUri($"episodes");
@@ -132,5 +135,7 @@ namespace SpotifyAPI.Web
     public static Uri Markets() => EUri($"markets");
 
     private static Uri EUri(FormattableString path) => new(path.ToString(_provider), UriKind.Relative);
+
+    public static Uri TracksRecommendation() => EUri($"recommendations");
   }
 }


### PR DESCRIPTION
Hi! Thanks for the library, im using, and miss some feature i want to use like this:

This feature adds a recommendation engine that generates recommendations based on the available information for a given seed entity. The engine matches the seed entity against similar artists and tracks, and if there is sufficient information available, a list of recommended tracks is returned along with pool size details.