### PR TITLE
Improve getting-started proposing Client Credentials flow

### DIFF
--- a/SpotifyAPI.Docs/docs/getting_started.md
+++ b/SpotifyAPI.Docs/docs/getting_started.md
@@ -59,6 +59,9 @@ class Program
 
 :::tip
 Notice that the spotify api does not allow unauthorized API access. Wondering where you should get an access token from? For a quick test, head over to the [Spotify Developer Console](https://developer.spotify.com/console/get-album/) and generate an access token with the required scopes! For a permanent solution, head over to the [authentication guides](auth_introduction.md).
+In particular, in order to setup a quick test, you can also follow the Client Credentials flow and generate the accessToken with the client id and client secret of a your application .
+To obtain a Client Id and Client Secret for that flow, you need to login in [Spotify Developer Console](https://developer.spotify.com/documentation/web-api/reference/get-an-album), going to your personal dashboard [Spotify Developer Dashboard Console](https://developer.spotify.com/dashboard) and create a client application.
+With those Client Id and Client Secret, simply follow the [client credential flow guide](client_credentials.md).
 
 :::
 


### PR DESCRIPTION
Hi @JohnnyCrazy  , first thank for this fantastic library.

I wanted to start to work from scratch with the implementation of a personal application, following my huge passion for music, and discovering that there is a Spotify library perfectly maintained for dotnet is very exciting and ispiring to me.

I would like to suggest, in the getting-started doc-guide, a short sentence that suggest the user to also consider to follow the Client Credential flow (perfectly explained in its specific section). 
I did that because I found that this could be a very fast and simple way to start with this library in a very few lines of code (for me it was very linear do that).

Hope to find you well with this message, have a nice coding.

Giova
