### PR TITLE
Update RecommendationsResponse to match Spotify API

### DIFF
--- a/SpotifyAPI.Web/Models/Response/RecommendationsResponse.cs
+++ b/SpotifyAPI.Web/Models/Response/RecommendationsResponse.cs
@@ -5,7 +5,7 @@ namespace SpotifyAPI.Web
   public class RecommendationsResponse
   {
     public List<RecommendationSeed> Seeds { get; set; } = default!;
-    public List<SimpleTrack> Tracks { get; set; } = default!;
+    public List<FullTrack> Tracks { get; set; } = default!;
   }
 }
 


### PR DESCRIPTION
The Spotify API returns full track information on the [Get Recommendations](https://developer.spotify.com/documentation/web-api/reference/get-recommendations) endpoint. 

It would be nice to update the library so we can have access to those additional properties that we might use and eliminate the need to make another request to get more information about the tracks.