### PR TITLE
[docs] Add note about including "next" field when using pagination

### DIFF
--- a/SpotifyAPI.Docs/docs/iplayableitem.md
+++ b/SpotifyAPI.Docs/docs/iplayableitem.md
@@ -54,3 +54,8 @@ By requesting just the track name from the items, we don't have any kind of type
 playlistGetItemsRequest.Fields.Add("items(track(name,type))");
 ```
 
+If you're paginating a request with a subset of fields and you don't include the field `next`, we assume there is only one page and your results will be limited. To fix this, you must include `next` as one of the fields:
+
+```csharp
+playlistGetItemsRequest.Fields.Add("next, items(track(name,type))");
+```


### PR DESCRIPTION
This just took 20 minutes of my life away, so I thought it would be worth adding to the docs to save anyone else from it!

Just `next` seemed to work for my case when using `PaginateAll` with `SimplePaginator` but I'm not sure if any of the other pagination fields might be needed for more niche scenarios.
