### PR TITLE
Add SupportsVolume in Device response

### DIFF
--- a/SpotifyAPI.Web/Models/Response/Device.cs
+++ b/SpotifyAPI.Web/Models/Response/Device.cs
@@ -7,6 +7,7 @@ namespace SpotifyAPI.Web
     public bool IsPrivateSession { get; set; }
     public bool IsRestricted { get; set; }
     public string Name { get; set; } = default!;
+    public bool SupportsVolume { get; set; }
     public string Type { get; set; } = default!;
     public int? VolumePercent { get; set; }
   }


### PR DESCRIPTION
A new property has been added to the web api, here's [the doc](https://developer.spotify.com/documentation/web-api/reference/get-information-about-the-users-current-playback#:~:text=supports_volume,set%20the%20volume.).