### PR TITLE
Fix Playlist.ReplaceItems response (#972)

### DIFF
--- a/SpotifyAPI.Web/Clients/Interfaces/IPlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IPlaylistsClient.cs
@@ -150,7 +150,7 @@ namespace SpotifyAPI.Web
     /// https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-replace-playlists-tracks
     /// </remarks>
     /// <returns></returns>
-    Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default);
+    Task<SnapshotResponse> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     /// Get a list of the playlists owned or followed by the current Spotify user.

--- a/SpotifyAPI.Web/Clients/PlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/PlaylistsClient.cs
@@ -101,7 +101,7 @@ namespace SpotifyAPI.Web
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return await API.Put<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
+      return API.Put<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel);
     }
 
     public Task<Paging<FullPlaylist>> CurrentUsers(CancellationToken cancel = default)

--- a/SpotifyAPI.Web/Clients/PlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/PlaylistsClient.cs
@@ -96,13 +96,12 @@ namespace SpotifyAPI.Web
       return API.Get<FullPlaylist>(URLs.Playlist(playlistId), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<bool> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default)
+    public async Task<SnapshotResponse> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      var statusCode = await API.Put(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
-      return statusCode == HttpStatusCode.Created;
+      return await API.Put<SnapshotResponse>(URLs.PlaylistTracks(playlistId), null, request.BuildBodyParams(), cancel).ConfigureAwait(false);
     }
 
     public Task<Paging<FullPlaylist>> CurrentUsers(CancellationToken cancel = default)

--- a/SpotifyAPI.Web/Clients/PlaylistsClient.cs
+++ b/SpotifyAPI.Web/Clients/PlaylistsClient.cs
@@ -96,7 +96,7 @@ namespace SpotifyAPI.Web
       return API.Get<FullPlaylist>(URLs.Playlist(playlistId), request.BuildQueryParams(), cancel);
     }
 
-    public async Task<SnapshotResponse> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default)
+    public Task<SnapshotResponse> ReplaceItems(string playlistId, PlaylistReplaceItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNullOrEmptyString(playlistId, nameof(playlistId));
       Ensure.ArgumentNotNull(request, nameof(request));


### PR DESCRIPTION
`PlaylistClient` method `ReplaceItems` now returns a `SnapshotResponse` instead of boolean. 
I removed the status code check, now the behavior is the same as for other non-primitive return types in `PlaylistClient`. 

This fixes issue #972 