### PR TITLE
feat: make top items paginatable

### DIFF
--- a/SpotifyAPI.Web/Clients/Interfaces/IUserProfileClient.cs
+++ b/SpotifyAPI.Web/Clients/Interfaces/IUserProfileClient.cs
@@ -36,7 +36,7 @@ namespace SpotifyAPI.Web
     /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks</remarks>
     /// <exception cref="APIUnauthorizedException">Thrown if the client is not authenticated.</exception>
-    Task<UsersTopTracksResponse> GetTopTracks(UsersTopItemsRequest request, CancellationToken cancel = default);
+    Task<CursorPaging<FullTrack>> GetTopTracks(UsersTopItemsRequest request, CancellationToken cancel = default);
 
     /// <summary>
     ///   Get Top arsists for the current user
@@ -45,6 +45,6 @@ namespace SpotifyAPI.Web
     /// <param name="cancel">The cancellation-token to allow to cancel the request.</param>
     /// <remarks>https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks</remarks>
     /// <exception cref="APIUnauthorizedException">Thrown if the client is not authenticated.</exception>
-    Task<UsersTopArtistsResponse> GetTopArtists(UsersTopItemsRequest request, CancellationToken cancel = default);
+    Task<CursorPaging<FullArtist>> GetTopArtists(UsersTopItemsRequest request, CancellationToken cancel = default);
   }
 }

--- a/SpotifyAPI.Web/Clients/UserProfileClient.cs
+++ b/SpotifyAPI.Web/Clients/UserProfileClient.cs
@@ -20,19 +20,19 @@ namespace SpotifyAPI.Web
       return API.Get<PublicUser>(SpotifyUrls.User(userId), cancel);
     }
 
-    public Task<UsersTopTracksResponse> GetTopTracks(UsersTopItemsRequest request, CancellationToken cancel = default)
+    public Task<CursorPaging<FullTrack>> GetTopTracks(UsersTopItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<UsersTopTracksResponse>(SpotifyUrls.TopTracks(), request.BuildQueryParams(), cancel);
+      return API.Get<CursorPaging<FullTrack>>(SpotifyUrls.TopTracks(), request.BuildQueryParams(), cancel);
 
     }
 
-    public Task<UsersTopArtistsResponse> GetTopArtists(UsersTopItemsRequest request, CancellationToken cancel = default)
+    public Task<CursorPaging<FullArtist>> GetTopArtists(UsersTopItemsRequest request, CancellationToken cancel = default)
     {
       Ensure.ArgumentNotNull(request, nameof(request));
 
-      return API.Get<UsersTopArtistsResponse>(SpotifyUrls.TopArtists(), request.BuildQueryParams(), cancel);
+      return API.Get<CursorPaging<FullArtist>>(SpotifyUrls.TopArtists(), request.BuildQueryParams(), cancel);
     }
   }
 }


### PR DESCRIPTION
To go along with [Issue 1016](https://github.com/JohnnyCrazy/SpotifyAPI-NET/issues/1016), here's a suggestion of how `SpotifyClient.UserProfile.GetTopArtists` and `SpotifyClient.UserProfile.GetTopTracks` can be adjusted, inspired by `SpotifyClient.Player.GetRecentlyPlayed`, which does have pagination